### PR TITLE
Restore and convert old tests to scalatest

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,12 +1,11 @@
-# Jerkson for Scala 2.10 #
+# Jerkson #
 
-[Jerkson](https://github.com/codahale/jerkson) has only been published for
-Scala versions as high as 2.9.1.
+This fork of Jerkson contains patches not found in the original, abandoned, copy.
 
 ## Differences from upstream Jerkson ##
 
 - sbt instead of Maven.
-- Tests have been deleted, since sbt cannot run
+- Tests have been converted to scalatest
   [simplespec](https://github.com/SimpleFinance/simplespec) tests.
 - Minor tweaks to get compilation in 2.10.
 - [Streaming iteration patch](https://github.com/ymasory/jerkson/pull/1), if you
@@ -20,15 +19,15 @@ Scala versions as high as 2.9.1.
 - From sbt:
 
   ```scala
-  libraryDependencies += "com.cloudphysics %% "jerkson" % "0.6.1"
+  libraryDependencies += "com.gilt %% "jerkson" % "0.6.8-2"
   ```
 - From Maven:
 
   ```xml
   <dependency>
-    <groupId>com.cloudphysics</groupId>
+    <groupId>com.gilt</groupId>
     <artifactId>jerkson_2.10</artifactId>
-    <version>0.6.1</version>
+    <version>0.6.8-2</version>
   </dependency>
   ```
 
@@ -37,6 +36,7 @@ Scala versions as high as 2.9.1.
 ```sh
 $ cd jerkson
 $ sbt compile
+$ sbt test
 ```
 
 ## Future plans ##

--- a/build.sbt
+++ b/build.sbt
@@ -58,7 +58,8 @@ javacOptions ++= Seq("-Xlint:unchecked", "-Xlint:deprecation")
 /* dependencies */
 libraryDependencies ++= Seq(
   "com.fasterxml.jackson.core" % "jackson-core" % "2.6.1",
-  "com.fasterxml.jackson.core" % "jackson-databind" % "2.6.1"
+  "com.fasterxml.jackson.core" % "jackson-databind" % "2.6.1",
+  "org.scalatest" %% "scalatest" % "2.2.6" % "test"
 )
 
 libraryDependencies <+= scalaVersion {

--- a/build.sbt
+++ b/build.sbt
@@ -68,7 +68,7 @@ libraryDependencies <+= scalaVersion {
 
 
 /* testing */
-parallelExecution in Test := false
+parallelExecution in Test := true
 
 /* sbt behavior */
 logLevel in compile := Level.Warn

--- a/src/test/scala/com/codahale/jerkson/tests/ASTTypeSupportSpec.scala
+++ b/src/test/scala/com/codahale/jerkson/tests/ASTTypeSupportSpec.scala
@@ -1,0 +1,125 @@
+package com.codahale.jerkson.tests
+
+import com.codahale.jerkson.Json._
+import com.codahale.jerkson.AST._
+import com.codahale.simplespec.Spec
+import org.junit.Test
+
+class ASTTypeSupportSpec extends Spec {
+  class `An AST.JInt` {
+    @Test def `generates a JSON int` = {
+      generate(JInt(15)).must(be("15"))
+    }
+
+    @Test def `is parsable from a JSON int` = {
+      parse[JInt]("15").must(be(JInt(15)))
+    }
+
+    @Test def `is parsable from a JSON int as a JValue` = {
+      parse[JValue]("15").must(be(JInt(15)))
+    }
+  }
+
+  class `An AST.JFloat` {
+    @Test def `generates a JSON int` = {
+      generate(JFloat(15.1)).must(be("15.1"))
+    }
+
+    @Test def `is parsable from a JSON float` = {
+      parse[JFloat]("15.1").must(be(JFloat(15.1)))
+    }
+
+    @Test def `is parsable from a JSON float as a JValue` = {
+      parse[JValue]("15.1").must(be(JFloat(15.1)))
+    }
+  }
+
+
+  class `An AST.JString` {
+    @Test def `generates a JSON string` = {
+      generate(JString("woo")).must(be("\"woo\""))
+    }
+
+    @Test def `is parsable from a JSON string` = {
+      parse[JString]("\"woo\"").must(be(JString("woo")))
+    }
+
+    @Test def `is parsable from a JSON string as a JValue` = {
+      parse[JValue]("\"woo\"").must(be(JString("woo")))
+    }
+  }
+
+  class `An AST.JNull` {
+    @Test def `generates a JSON null` = {
+      generate(JNull).must(be("null"))
+    }
+
+    @Test def `is parsable from a JSON null` = {
+      parse[JNull.type]("null").must(be(JNull))
+    }
+
+    @Test def `is parsable from a JSON null as a JValue` = {
+      parse[JValue]("null").must(be(JNull))
+    }
+  }
+
+  class `An AST.JBoolean` {
+    @Test def `generates a JSON true` = {
+      generate(JBoolean(true)).must(be("true"))
+    }
+
+    @Test def `generates a JSON false` = {
+      generate(JBoolean(false)).must(be("false"))
+    }
+
+    @Test def `is parsable from a JSON true` = {
+      parse[JBoolean]("true").must(be(JBoolean(true)))
+    }
+
+    @Test def `is parsable from a JSON false` = {
+      parse[JBoolean]("false").must(be(JBoolean(false)))
+    }
+
+    @Test def `is parsable from a JSON true as a JValue` = {
+      parse[JValue]("true").must(be(JBoolean(true)))
+    }
+
+    @Test def `is parsable from a JSON false as a JValue` = {
+      parse[JValue]("false").must(be(JBoolean(false)))
+    }
+  }
+
+  class `An AST.JArray of JInts` {
+    @Test def `generates a JSON array of ints` = {
+      generate(JArray(List(JInt(1), JInt(2), JInt(3)))).must(be("[1,2,3]"))
+    }
+
+    @Test def `is parsable from a JSON array of ints` = {
+      parse[JArray]("[1,2,3]").must(be(JArray(List(JInt(1), JInt(2), JInt(3)))))
+    }
+
+    @Test def `is parsable from a JSON array of ints as a JValue` = {
+      parse[JValue]("[1,2,3]").must(be(JArray(List(JInt(1), JInt(2), JInt(3)))))
+    }
+  }
+
+  class `An AST.JObject` {
+    val obj = JObject(List(JField("id", JInt(1)), JField("name", JString("Coda"))))
+
+    @Test def `generates a JSON object with matching field values` = {
+      generate(obj).must(be("""{"id":1,"name":"Coda"}"""))
+    }
+
+    @Test def `is parsable from a JSON object` = {
+      parse[JObject]("""{"id":1,"name":"Coda"}""").must(be(obj))
+    }
+
+    @Test def `is parsable from a JSON object as a JValue` = {
+      parse[JValue]("""{"id":1,"name":"Coda"}""").must(be(obj))
+    }
+
+    @Test def `is parsable from an empty JSON object` = {
+      parse[JObject]("""{}""").must(be(JObject(Nil)))
+    }
+  }
+}

--- a/src/test/scala/com/codahale/jerkson/tests/ASTTypeSupportSpec.scala
+++ b/src/test/scala/com/codahale/jerkson/tests/ASTTypeSupportSpec.scala
@@ -2,124 +2,126 @@ package com.codahale.jerkson.tests
 
 import com.codahale.jerkson.Json._
 import com.codahale.jerkson.AST._
-import com.codahale.simplespec.Spec
-import org.junit.Test
+import org.scalatest.FlatSpec
+import org.scalatest.Matchers
 
-class ASTTypeSupportSpec extends Spec {
-  class `An AST.JInt` {
-    @Test def `generates a JSON int` = {
-      generate(JInt(15)).must(be("15"))
-    }
+class ASTTypeSupportSpec extends FlatSpec with Matchers {
 
-    @Test def `is parsable from a JSON int` = {
-      parse[JInt]("15").must(be(JInt(15)))
-    }
+  behavior of "An AST.JInt"
 
-    @Test def `is parsable from a JSON int as a JValue` = {
-      parse[JValue]("15").must(be(JInt(15)))
-    }
+  it should "generate a JSON int" in {
+    generate(JInt(15)) should be("15")
   }
 
-  class `An AST.JFloat` {
-    @Test def `generates a JSON int` = {
-      generate(JFloat(15.1)).must(be("15.1"))
-    }
+  it should "is parsable from a JSON int" in {
+    parse[JInt]("15") shouldBe JInt(15)
+  }
 
-    @Test def `is parsable from a JSON float` = {
-      parse[JFloat]("15.1").must(be(JFloat(15.1)))
-    }
-
-    @Test def `is parsable from a JSON float as a JValue` = {
-      parse[JValue]("15.1").must(be(JFloat(15.1)))
-    }
+  it should "is parsable from a JSON int as a JValue" in {
+    parse[JValue]("15") shouldBe JInt(15)
   }
 
 
-  class `An AST.JString` {
-    @Test def `generates a JSON string` = {
-      generate(JString("woo")).must(be("\"woo\""))
-    }
+  behavior of "An AST.JFloat"
 
-    @Test def `is parsable from a JSON string` = {
-      parse[JString]("\"woo\"").must(be(JString("woo")))
-    }
-
-    @Test def `is parsable from a JSON string as a JValue` = {
-      parse[JValue]("\"woo\"").must(be(JString("woo")))
-    }
+  it should "generate a JSON int" in {
+    generate(JFloat(15.1)) shouldBe "15.1"
   }
 
-  class `An AST.JNull` {
-    @Test def `generates a JSON null` = {
-      generate(JNull).must(be("null"))
-    }
-
-    @Test def `is parsable from a JSON null` = {
-      parse[JNull.type]("null").must(be(JNull))
-    }
-
-    @Test def `is parsable from a JSON null as a JValue` = {
-      parse[JValue]("null").must(be(JNull))
-    }
+  it should "is parsable from a JSON float" in {
+    parse[JFloat]("15.1") shouldBe JFloat(15.1)
   }
 
-  class `An AST.JBoolean` {
-    @Test def `generates a JSON true` = {
-      generate(JBoolean(true)).must(be("true"))
-    }
-
-    @Test def `generates a JSON false` = {
-      generate(JBoolean(false)).must(be("false"))
-    }
-
-    @Test def `is parsable from a JSON true` = {
-      parse[JBoolean]("true").must(be(JBoolean(true)))
-    }
-
-    @Test def `is parsable from a JSON false` = {
-      parse[JBoolean]("false").must(be(JBoolean(false)))
-    }
-
-    @Test def `is parsable from a JSON true as a JValue` = {
-      parse[JValue]("true").must(be(JBoolean(true)))
-    }
-
-    @Test def `is parsable from a JSON false as a JValue` = {
-      parse[JValue]("false").must(be(JBoolean(false)))
-    }
+  it should "is parsable from a JSON float as a JValue" in {
+    parse[JValue]("15.1") shouldBe JFloat(15.1)
   }
 
-  class `An AST.JArray of JInts` {
-    @Test def `generates a JSON array of ints` = {
-      generate(JArray(List(JInt(1), JInt(2), JInt(3)))).must(be("[1,2,3]"))
-    }
 
-    @Test def `is parsable from a JSON array of ints` = {
-      parse[JArray]("[1,2,3]").must(be(JArray(List(JInt(1), JInt(2), JInt(3)))))
-    }
+  behavior of "An AST.JString"
 
-    @Test def `is parsable from a JSON array of ints as a JValue` = {
-      parse[JValue]("[1,2,3]").must(be(JArray(List(JInt(1), JInt(2), JInt(3)))))
-    }
+  it should "generate a JSON string" in {
+    generate(JString("woo")) shouldBe "\"woo\""
   }
 
-  class `An AST.JObject` {
-    val obj = JObject(List(JField("id", JInt(1)), JField("name", JString("Coda"))))
+  it should "is parsable from a JSON string" in {
+    parse[JString]("\"woo\"") shouldBe JString("woo")
+  }
 
-    @Test def `generates a JSON object with matching field values` = {
-      generate(obj).must(be("""{"id":1,"name":"Coda"}"""))
-    }
+  it should "is parsable from a JSON string as a JValue" in {
+    parse[JValue]("\"woo\"") shouldBe JString("woo")
+  }
 
-    @Test def `is parsable from a JSON object` = {
-      parse[JObject]("""{"id":1,"name":"Coda"}""").must(be(obj))
-    }
 
-    @Test def `is parsable from a JSON object as a JValue` = {
-      parse[JValue]("""{"id":1,"name":"Coda"}""").must(be(obj))
-    }
+  behavior of "An AST.JNull"
+  it should "generates a JSON null" in {
+    generate(JNull) shouldBe "null"
+  }
 
-    @Test def `is parsable from an empty JSON object` = {
-      parse[JObject]("""{}""").must(be(JObject(Nil)))
-    }
+  it should "is parsable from a JSON null" in {
+    parse[JNull.type]("null") shouldBe JNull
+  }
+
+  it should "is parsable from a JSON null as a JValue" in {
+    parse[JValue]("null") shouldBe JNull
+  }
+
+
+  behavior of "An AST.JBoolean"
+  it should "generates a JSON true" in {
+    generate(JBoolean(true)) shouldBe "true"
+  }
+
+  it should "generates a JSON false" in {
+    generate(JBoolean(false)) shouldBe "false"
+  }
+
+  it should "is parsable from a JSON true" in {
+    parse[JBoolean]("true") shouldBe JBoolean(true)
+  }
+
+  it should "is parsable from a JSON false" in {
+    parse[JBoolean]("false") shouldBe JBoolean(false)
+  }
+
+  it should "is parsable from a JSON true as a JValue" in {
+    parse[JValue]("true") shouldBe JBoolean(true)
+  }
+
+  it should "is parsable from a JSON false as a JValue" in {
+    parse[JValue]("false") shouldBe JBoolean(false)
+  }
+
+
+  behavior of "An AST.JArray of JInts"
+  it should "generates a JSON array of ints" in {
+    generate(JArray(List(JInt(1), JInt(2), JInt(3)))) shouldBe "[1,2,3]"
+  }
+
+  it should "is parsable from a JSON array of ints" in {
+    parse[JArray]("[1,2,3]") shouldBe JArray(List(JInt(1), JInt(2), JInt(3)))
+  }
+
+  it should "is parsable from a JSON array of ints as a JValue" in {
+    parse[JValue]("[1,2,3]") shouldBe JArray(List(JInt(1), JInt(2), JInt(3)))
+  }
+
+
+  behavior of "An AST.JObject"
+  val obj = JObject(List(JField("id", JInt(1)), JField("name", JString("Coda"))))
+
+  it should "generates a JSON object with matching field values" in {
+    generate(obj) shouldBe """{"id":1,"name":"Coda"}"""
+  }
+
+  it should "is parsable from a JSON object" in {
+    parse[JObject]("""{"id":1,"name":"Coda"}""") shouldBe obj
+  }
+
+  it should "is parsable from a JSON object as a JValue" in {
+    parse[JValue]("""{"id":1,"name":"Coda"}""") shouldBe obj
+  }
+
+  it should "is parsable from an empty JSON object" in {
+    parse[JObject]("""{}""") shouldBe JObject(Nil)
   }
 }

--- a/src/test/scala/com/codahale/jerkson/tests/BasicTypeSupportSpec.scala
+++ b/src/test/scala/com/codahale/jerkson/tests/BasicTypeSupportSpec.scala
@@ -1,217 +1,217 @@
 package com.codahale.jerkson.tests
 
-import com.codahale.simplespec.Spec
 import com.codahale.jerkson.Json._
 import com.fasterxml.jackson.databind.node.IntNode
 import com.fasterxml.jackson.databind.JsonNode
-import org.junit.Test
+import org.scalatest.FlatSpec
+import org.scalatest.Matchers
 
-class BasicTypeSupportSpec extends Spec {
-  class `A Byte` {
-    @Test def `generates a JSON int` = {
-      generate(15.toByte).must(be("15"))
-    }
+class BasicTypeSupportSpec extends FlatSpec with Matchers {
 
-    @Test def `is parsable from a JSON int` = {
-      parse[Byte]("15").must(be(15))
-    }
+  behavior of "A Byte"
+  it should "generates a JSON int" in {
+    generate(15.toByte) shouldBe "15"
   }
 
-  class `A Short` {
-    @Test def `generates a JSON int` = {
-      generate(15.toShort).must(be("15"))
-    }
-
-    @Test def `is parsable from a JSON int` = {
-      parse[Short]("15").must(be(15))
-    }
+  it should "is parsable from a JSON int" in {
+    parse[Byte]("15") shouldBe 15
   }
 
-  class `An Int` {
-    @Test def `generates a JSON int` = {
-      generate(15).must(be("15"))
-    }
 
-    @Test def `is parsable from a JSON int` = {
-      parse[Int]("15").must(be(15))
-    }
+  behavior of "A Short"
+  it should "generates a JSON int" in {
+    generate(15.toShort) shouldBe "15"
   }
 
-  class `A Long` {
-    @Test def `generates a JSON int` = {
-      generate(15L).must(be("15"))
-    }
-
-    @Test def `is parsable from a JSON int` = {
-      parse[Long]("15").must(be(15L))
-    }
+  it should "is parsable from a JSON int" in {
+    parse[Short]("15") shouldBe 15
   }
 
-  class `A BigInt` {
-    @Test def `generates a JSON int` = {
-      generate(BigInt(15)).must(be("15"))
-    }
 
-    @Test def `is parsable from a JSON int` = {
-      parse[BigInt]("15").must(be(BigInt(15)))
-    }
-
-    @Test def `is parsable from a JSON string` = {
-      parse[BigInt]("\"15\"").must(be(BigInt(15)))
-    }
+  behavior of "An Int"
+  it should "generates a JSON int" in {
+    generate(15) shouldBe "15"
   }
 
-  class `A Float` {
-    @Test def `generates a JSON float` = {
-      generate(15.1F).must(be("15.1"))
-    }
-
-    @Test def `is parsable from a JSON float` = {
-      parse[Float]("15.1").must(be(15.1F))
-    }
+  it should "is parsable from a JSON int" in {
+    parse[Int]("15") shouldBe 15
   }
 
-  class `A Double` {
-    @Test def `generates a JSON float` = {
-      generate(15.1).must(be("15.1"))
-    }
 
-    @Test def `is parsable from a JSON float` = {
-      parse[Double]("15.1").must(be(15.1D))
-    }
+  behavior of "A Long"
+  it should "generates a JSON int" in {
+    generate(15L) shouldBe "15"
   }
 
-  class `A BigDecimal` {
-    @Test def `generates a JSON float` = {
-      generate(BigDecimal(15.5)).must(be("15.5"))
-    }
-
-    @Test def `is parsable from a JSON float` = {
-      parse[BigDecimal]("15.5").must(be(BigDecimal(15.5)))
-    }
-
-    @Test def `is parsable from a JSON int` = {
-      parse[BigDecimal]("15").must(be(BigDecimal(15.0)))
-    }
+  it should "is parsable from a JSON int" in {
+    parse[Long]("15") shouldBe 15L
   }
 
-  class `A String` {
-    @Test def `generates a JSON string` = {
-      generate("woo").must(be("\"woo\""))
-    }
 
-    @Test def `is parsable from a JSON string` = {
-      parse[String]("\"woo\"").must(be("woo"))
-    }
+  behavior of "A BigInt"
+  it should "generates a JSON int" in {
+    generate(BigInt(15)) shouldBe "15"
   }
 
-  class `A StringBuilder` {
-    @Test def `generates a JSON string` = {
-      generate(new StringBuilder("foo")).must(be("\"foo\""))
-    }
-
-    @Test def `is parsable from a JSON string` = {
-      parse[StringBuilder]("\"foo\"").toString().must(be("foo"))
-    }
+  it should "is parsable from a JSON int" in {
+    parse[BigInt]("15") shouldBe BigInt(15)
   }
 
-  class `A null Object` {
-    @Test def `generates a JSON null` = {
-      generate[Object](null).must(be("null"))
-    }
-
-    @Test def `is parsable from a JSON null` = {
-      parse[Object]("null").must(be(not(notNull)))
-    }
+  it should "is parsable from a JSON string" in {
+    parse[BigInt]("\"15\"") shouldBe BigInt(15)
   }
 
-  class `A Boolean` {
-    @Test def `generates a JSON true` = {
-      generate(true).must(be("true"))
-    }
 
-    @Test def `generates a JSON false` = {
-      generate(false).must(be("false"))
-    }
-
-    @Test def `is parsable from a JSON true` = {
-      parse[Boolean]("true").must(be(true))
-    }
-
-    @Test def `is parsable from a JSON false` = {
-      parse[Boolean]("false").must(be(false))
-    }
+  behavior of "A Float"
+  it should "generates a JSON float" in {
+    generate(15.1F) shouldBe "15.1"
   }
 
-  class `A Some[Int]` {
-    @Test def `generates a JSON int` = {
-      generate(Some(12)).must(be("12"))
-    }
-
-    @Test def `is parsable from a JSON int as an Option[Int]` = {
-      parse[Option[Int]]("12").must(be(Some(12)))
-    }
+  it should "is parsable from a JSON float" in {
+    parse[Float]("15.1") shouldBe 15.1F
   }
 
-  class `A None` {
-    @Test def `generates a JSON null` = {
-      generate(None).must(be("null"))
-    }
 
-    @Test def `is parsable from a JSON null as an Option[Int]` = {
-      parse[Option[Int]]("null").must(be(None))
-    }
+  behavior of "A Double"
+  it should "generates a JSON float" in {
+    generate(15.1) shouldBe "15.1"
   }
 
-  class `A Left[String]` {
-    @Test def `generates a JSON string` = {
-      generate(Left("woo")).must(be("\"woo\""))
-    }
-
-    @Test def `is parsable from a JSON string as an Either[String, Int]` = {
-      parse[Either[String, Int]]("\"woo\"").must(be(Left("woo")))
-    }
+  it should "is parsable from a JSON float" in {
+    parse[Double]("15.1") shouldBe 15.1D
   }
 
-  class `A Right[String]` {
-    @Test def `generates a JSON string` = {
-      generate(Right("woo")).must(be("\"woo\""))
-    }
 
-    @Test def `is parsable from a JSON string as an Either[Int, String]` = {
-      parse[Either[Int, String]]("\"woo\"").must(be(Right("woo")))
-    }
+  behavior of "A BigDecimal"
+  it should "generates a JSON float" in {
+    generate(BigDecimal(15.5)) shouldBe "15.5"
   }
 
-  class `A JsonNode` {
-    @Test def `generates whatever the JsonNode is` = {
-      generate(new IntNode(2)).must(be("2"))
-    }
-
-    @Test def `is parsable from a JSON AST node` = {
-      parse[JsonNode]("2").must(be(new IntNode(2)))
-    }
-
-    @Test def `is parsable from a JSON AST node as a specific type` = {
-      parse[IntNode]("2").must(be(new IntNode(2)))
-    }
-
-    @Test def `is itself parsable` = {
-      parse[Int](new IntNode(2)).must(be(2))
-    }
+  it should "is parsable from a JSON float" in {
+    parse[BigDecimal]("15.5") shouldBe BigDecimal(15.5)
   }
 
-  class `An Array[Int]` {
-    @Test def `generates a JSON array of ints` = {
-      generate(Array(1, 2, 3)).must(be("[1,2,3]"))
-    }
+  it should "is parsable from a JSON int" in {
+    parse[BigDecimal]("15") shouldBe BigDecimal(15.0)
+  }
 
-    @Test def `is parsable from a JSON array of ints` = {
-      parse[Array[Int]]("[1,2,3]").toList.must(be(List(1, 2, 3)))
-    }
 
-    @Test def `is parsable from an empty JSON array` = {
-      parse[Array[Int]]("[]").toList.must(be(List.empty))
-    }
+  behavior of "A String"
+  it should "generates a JSON string" in {
+    generate("woo") shouldBe "\"woo\""
+  }
+
+  it should "is parsable from a JSON string" in {
+    parse[String]("\"woo\"") shouldBe "woo"
+  }
+
+
+  behavior of "A StringBuilder"
+  it should "generates a JSON string" in {
+    generate(new StringBuilder("foo")) shouldBe "\"foo\""
+  }
+
+  it should "is parsable from a JSON string" in {
+    parse[StringBuilder]("\"foo\"").toString() shouldBe "foo"
+  }
+
+
+  behavior of "A null Object"
+  it should "generates a JSON null" in {
+    generate[Object](null) shouldBe "null"
+  }
+
+  it should "is parsable from a JSON null" in {
+    parse[Object]("null") shouldBe null
+  }
+
+
+  behavior of "A Boolean"
+  it should "generates a JSON true" in {
+    generate(true) shouldBe "true"
+  }
+
+  it should "generates a JSON false" in {
+    generate(false) shouldBe "false"
+  }
+
+  it should "is parsable from a JSON true" in {
+    parse[Boolean]("true") shouldBe true
+  }
+
+  it should "is parsable from a JSON false" in {
+    parse[Boolean]("false") shouldBe false
+  }
+
+
+  behavior of "A Some[Int]"
+  it should "generates a JSON int" in {
+    generate(Some(12)) shouldBe "12"
+  }
+
+  it should "is parsable from a JSON int as an Option[Int]" in {
+    parse[Option[Int]]("12") shouldBe Some(12)
+  }
+
+
+  behavior of "A None"
+  it should "generates a JSON null" in {
+    generate(None) shouldBe "null"
+  }
+
+  it should "is parsable from a JSON null as an Option[Int]" in {
+    parse[Option[Int]]("null") shouldBe None
+  }
+
+
+  behavior of "A Left[String]"
+  it should "generates a JSON string" in {
+    generate(Left("woo")) shouldBe "\"woo\""
+  }
+
+  it should "is parsable from a JSON string as an Either[String, Int]" in {
+    parse[Either[String, Int]]("\"woo\"") shouldBe Left("woo")
+  }
+
+
+  behavior of "A Right[String]"
+  it should "generates a JSON string" in {
+    generate(Right("woo")) shouldBe "\"woo\""
+  }
+
+  it should "is parsable from a JSON string as an Either[Int, String]" in {
+    parse[Either[Int, String]]("\"woo\"") shouldBe Right("woo")
+  }
+
+
+  behavior of "A JsonNode"
+  it should "generates whatever the JsonNode is" in {
+    generate(new IntNode(2)) shouldBe "2"
+  }
+
+  it should "is parsable from a JSON AST node" in {
+    parse[JsonNode]("2") shouldBe new IntNode(2)
+  }
+
+  it should "is parsable from a JSON AST node as a specific type" in {
+    parse[IntNode]("2") shouldBe new IntNode(2)
+  }
+
+  it should "is itself parsable" in {
+    parse[Int](new IntNode(2)) shouldBe 2
+  }
+
+
+  behavior of "An Array[Int]"
+  it should "generates a JSON array of ints" in {
+    generate(Array(1, 2, 3)) shouldBe "[1,2,3]"
+  }
+
+  it should "is parsable from a JSON array of ints" in {
+    parse[Array[Int]]("[1,2,3]").toList shouldBe List(1, 2, 3)
+  }
+
+  it should "is parsable from an empty JSON array" in {
+    parse[Array[Int]]("[]").toList shouldBe List.empty
   }
 }

--- a/src/test/scala/com/codahale/jerkson/tests/BasicTypeSupportSpec.scala
+++ b/src/test/scala/com/codahale/jerkson/tests/BasicTypeSupportSpec.scala
@@ -1,0 +1,217 @@
+package com.codahale.jerkson.tests
+
+import com.codahale.simplespec.Spec
+import com.codahale.jerkson.Json._
+import com.fasterxml.jackson.databind.node.IntNode
+import com.fasterxml.jackson.databind.JsonNode
+import org.junit.Test
+
+class BasicTypeSupportSpec extends Spec {
+  class `A Byte` {
+    @Test def `generates a JSON int` = {
+      generate(15.toByte).must(be("15"))
+    }
+
+    @Test def `is parsable from a JSON int` = {
+      parse[Byte]("15").must(be(15))
+    }
+  }
+
+  class `A Short` {
+    @Test def `generates a JSON int` = {
+      generate(15.toShort).must(be("15"))
+    }
+
+    @Test def `is parsable from a JSON int` = {
+      parse[Short]("15").must(be(15))
+    }
+  }
+
+  class `An Int` {
+    @Test def `generates a JSON int` = {
+      generate(15).must(be("15"))
+    }
+
+    @Test def `is parsable from a JSON int` = {
+      parse[Int]("15").must(be(15))
+    }
+  }
+
+  class `A Long` {
+    @Test def `generates a JSON int` = {
+      generate(15L).must(be("15"))
+    }
+
+    @Test def `is parsable from a JSON int` = {
+      parse[Long]("15").must(be(15L))
+    }
+  }
+
+  class `A BigInt` {
+    @Test def `generates a JSON int` = {
+      generate(BigInt(15)).must(be("15"))
+    }
+
+    @Test def `is parsable from a JSON int` = {
+      parse[BigInt]("15").must(be(BigInt(15)))
+    }
+
+    @Test def `is parsable from a JSON string` = {
+      parse[BigInt]("\"15\"").must(be(BigInt(15)))
+    }
+  }
+
+  class `A Float` {
+    @Test def `generates a JSON float` = {
+      generate(15.1F).must(be("15.1"))
+    }
+
+    @Test def `is parsable from a JSON float` = {
+      parse[Float]("15.1").must(be(15.1F))
+    }
+  }
+
+  class `A Double` {
+    @Test def `generates a JSON float` = {
+      generate(15.1).must(be("15.1"))
+    }
+
+    @Test def `is parsable from a JSON float` = {
+      parse[Double]("15.1").must(be(15.1D))
+    }
+  }
+
+  class `A BigDecimal` {
+    @Test def `generates a JSON float` = {
+      generate(BigDecimal(15.5)).must(be("15.5"))
+    }
+
+    @Test def `is parsable from a JSON float` = {
+      parse[BigDecimal]("15.5").must(be(BigDecimal(15.5)))
+    }
+
+    @Test def `is parsable from a JSON int` = {
+      parse[BigDecimal]("15").must(be(BigDecimal(15.0)))
+    }
+  }
+
+  class `A String` {
+    @Test def `generates a JSON string` = {
+      generate("woo").must(be("\"woo\""))
+    }
+
+    @Test def `is parsable from a JSON string` = {
+      parse[String]("\"woo\"").must(be("woo"))
+    }
+  }
+
+  class `A StringBuilder` {
+    @Test def `generates a JSON string` = {
+      generate(new StringBuilder("foo")).must(be("\"foo\""))
+    }
+
+    @Test def `is parsable from a JSON string` = {
+      parse[StringBuilder]("\"foo\"").toString().must(be("foo"))
+    }
+  }
+
+  class `A null Object` {
+    @Test def `generates a JSON null` = {
+      generate[Object](null).must(be("null"))
+    }
+
+    @Test def `is parsable from a JSON null` = {
+      parse[Object]("null").must(be(not(notNull)))
+    }
+  }
+
+  class `A Boolean` {
+    @Test def `generates a JSON true` = {
+      generate(true).must(be("true"))
+    }
+
+    @Test def `generates a JSON false` = {
+      generate(false).must(be("false"))
+    }
+
+    @Test def `is parsable from a JSON true` = {
+      parse[Boolean]("true").must(be(true))
+    }
+
+    @Test def `is parsable from a JSON false` = {
+      parse[Boolean]("false").must(be(false))
+    }
+  }
+
+  class `A Some[Int]` {
+    @Test def `generates a JSON int` = {
+      generate(Some(12)).must(be("12"))
+    }
+
+    @Test def `is parsable from a JSON int as an Option[Int]` = {
+      parse[Option[Int]]("12").must(be(Some(12)))
+    }
+  }
+
+  class `A None` {
+    @Test def `generates a JSON null` = {
+      generate(None).must(be("null"))
+    }
+
+    @Test def `is parsable from a JSON null as an Option[Int]` = {
+      parse[Option[Int]]("null").must(be(None))
+    }
+  }
+
+  class `A Left[String]` {
+    @Test def `generates a JSON string` = {
+      generate(Left("woo")).must(be("\"woo\""))
+    }
+
+    @Test def `is parsable from a JSON string as an Either[String, Int]` = {
+      parse[Either[String, Int]]("\"woo\"").must(be(Left("woo")))
+    }
+  }
+
+  class `A Right[String]` {
+    @Test def `generates a JSON string` = {
+      generate(Right("woo")).must(be("\"woo\""))
+    }
+
+    @Test def `is parsable from a JSON string as an Either[Int, String]` = {
+      parse[Either[Int, String]]("\"woo\"").must(be(Right("woo")))
+    }
+  }
+
+  class `A JsonNode` {
+    @Test def `generates whatever the JsonNode is` = {
+      generate(new IntNode(2)).must(be("2"))
+    }
+
+    @Test def `is parsable from a JSON AST node` = {
+      parse[JsonNode]("2").must(be(new IntNode(2)))
+    }
+
+    @Test def `is parsable from a JSON AST node as a specific type` = {
+      parse[IntNode]("2").must(be(new IntNode(2)))
+    }
+
+    @Test def `is itself parsable` = {
+      parse[Int](new IntNode(2)).must(be(2))
+    }
+  }
+
+  class `An Array[Int]` {
+    @Test def `generates a JSON array of ints` = {
+      generate(Array(1, 2, 3)).must(be("[1,2,3]"))
+    }
+
+    @Test def `is parsable from a JSON array of ints` = {
+      parse[Array[Int]]("[1,2,3]").toList.must(be(List(1, 2, 3)))
+    }
+
+    @Test def `is parsable from an empty JSON array` = {
+      parse[Array[Int]]("[]").toList.must(be(List.empty))
+    }
+  }
+}

--- a/src/test/scala/com/codahale/jerkson/tests/CaseClassSupportSpec.scala
+++ b/src/test/scala/com/codahale/jerkson/tests/CaseClassSupportSpec.scala
@@ -1,0 +1,239 @@
+package com.codahale.jerkson.tests
+
+import com.codahale.jerkson.Json._
+import com.codahale.simplespec.Spec
+import com.codahale.jerkson.ParsingException
+import com.fasterxml.jackson.databind.node.IntNode
+import org.junit.Test
+
+class CaseClassSupportSpec extends Spec {
+  class `A basic case class` {
+    @Test def `generates a JSON object with matching field values` = {
+      generate(CaseClass(1, "Coda")).must(be("""{"id":1,"name":"Coda"}"""))
+    }
+
+    @Test def `is parsable from a JSON object with corresponding fields` = {
+      parse[CaseClass]("""{"id":1,"name":"Coda"}""").must(be(CaseClass(1, "Coda")))
+    }
+
+    @Test def `is parsable from a JSON object with extra fields` = {
+      parse[CaseClass]("""{"id":1,"name":"Coda","derp":100}""").must(be(CaseClass(1, "Coda")))
+    }
+
+    @Test def `is not parsable from an incomplete JSON object` = {
+      evaluating {
+        parse[CaseClass]("""{"id":1}""")
+      }.must(throwA[ParsingException]("""Invalid JSON. Needed [id, name], but found [id]."""))
+    }
+  }
+
+  class `A case class with lazy fields` {
+    @Test def `generates a JSON object with those fields evaluated` = {
+      generate(CaseClassWithLazyVal(1)).must(be("""{"id":1,"woo":"yeah"}"""))
+    }
+
+    @Test def `is parsable from a JSON object without those fields` = {
+      parse[CaseClassWithLazyVal]("""{"id":1}""").must(be(CaseClassWithLazyVal(1)))
+    }
+
+    @Test def `is not parsable from an incomplete JSON object` = {
+      evaluating {
+        parse[CaseClassWithLazyVal]("""{}""")
+      }.must(throwA[ParsingException]("""Invalid JSON. Needed [id], but found []."""))
+    }
+  }
+
+  class `A case class with ignored members` {
+    @Test def `generates a JSON object without those fields` = {
+      generate(CaseClassWithIgnoredField(1)).must(be("""{"id":1}"""))
+      generate(CaseClassWithIgnoredFields(1)).must(be("""{"id":1}"""))
+    }
+
+    @Test def `is parsable from a JSON object without those fields` = {
+      parse[CaseClassWithIgnoredField]("""{"id":1}""").must(be(CaseClassWithIgnoredField(1)))
+      parse[CaseClassWithIgnoredFields]("""{"id":1}""").must(be(CaseClassWithIgnoredFields(1)))
+    }
+
+    @Test def `is not parsable from an incomplete JSON object` = {
+      evaluating {
+        parse[CaseClassWithIgnoredField]("""{}""")
+      }.must(throwA[ParsingException]("""Invalid JSON. Needed [id], but found []."""))
+
+      evaluating {
+        parse[CaseClassWithIgnoredFields]("""{}""")
+      }.must(throwA[ParsingException]("""Invalid JSON. Needed [id], but found []."""))
+    }
+  }
+
+  class `A case class with transient members` {
+    @Test def `generates a JSON object without those fields` = {
+      generate(CaseClassWithTransientField(1)).must(be("""{"id":1}"""))
+    }
+
+    @Test def `is parsable from a JSON object without those fields` = {
+      parse[CaseClassWithTransientField]("""{"id":1}""").must(be(CaseClassWithTransientField(1)))
+    }
+
+    @Test def `is not parsable from an incomplete JSON object` = {
+      evaluating {
+        parse[CaseClassWithTransientField]("""{}""")
+      }.must(throwA[ParsingException]("""Invalid JSON. Needed [id], but found []."""))
+    }
+  }
+
+  class `A case class with an overloaded field` {
+    @Test def `generates a JSON object with the nullary version of that field` = {
+      generate(CaseClassWithOverloadedField(1)).must(be("""{"id":1}"""))
+    }
+  }
+
+  class `A case class with an Option[String] member` {
+    @Test def `generates a field if the member is Some` = {
+      generate(CaseClassWithOption(Some("what"))).must(be("""{"value":"what"}"""))
+    }
+
+    @Test def `is parsable from a JSON object with that field` = {
+      parse[CaseClassWithOption]("""{"value":"what"}""").must(be(CaseClassWithOption(Some("what"))))
+    }
+
+    @Test def `doesn't generate a field if the member is None` = {
+      generate(CaseClassWithOption(None)).must(be("""{}"""))
+    }
+
+    @Test def `is parsable from a JSON object without that field` = {
+      parse[CaseClassWithOption]("""{}""").must(be(CaseClassWithOption(None)))
+    }
+
+    @Test def `is parsable from a JSON object with a null value for that field` = {
+      parse[CaseClassWithOption]("""{"value":null}""").must(be(CaseClassWithOption(None)))
+    }
+  }
+
+  class `A case class with a JsonNode member` {
+    @Test def `generates a field of the given type` = {
+      generate(CaseClassWithJsonNode(new IntNode(2))).must(be("""{"value":2}"""))
+    }
+  }
+
+  class `A case class with members of all ScalaSig types` {
+    val json = """
+               {
+                 "map": {
+                   "one": "two"
+                 },
+                 "set": [1, 2, 3],
+                 "string": "woo",
+                 "list": [4, 5, 6],
+                 "seq": [7, 8, 9],
+                 "sequence": [10, 11, 12],
+                 "collection": [13, 14, 15],
+                 "indexedSeq": [16, 17, 18],
+                 "randomAccessSeq": [19, 20, 21],
+                 "vector": [22, 23, 24],
+                 "bigDecimal": 12.0,
+                 "bigInt": 13,
+                 "int": 1,
+                 "long": 2,
+                 "char": "x",
+                 "bool": false,
+                 "short": 14,
+                 "byte": 15,
+                 "float": 34.5,
+                 "double": 44.9,
+                 "any": true,
+                 "anyRef": "wah",
+                 "intMap": {
+                   "1": "1"
+                 },
+                 "longMap": {
+                   "2": 2
+                 }
+               }
+               """
+
+
+    @Test def `is parsable from a JSON object with those fields` = {
+      parse[CaseClassWithAllTypes](json).must(be(
+        CaseClassWithAllTypes(
+          map = Map("one" -> "two"),
+          set = Set(1, 2, 3),
+          string = "woo",
+          list = List(4, 5, 6),
+          seq = Seq(7, 8, 9),
+          indexedSeq = IndexedSeq(16, 17, 18),
+          vector = Vector(22, 23, 24),
+          bigDecimal = BigDecimal("12.0"),
+          bigInt = BigInt("13"),
+          int = 1,
+          long = 2L,
+          char = 'x',
+          bool = false,
+          short = 14,
+          byte = 15,
+          float = 34.5f,
+          double = 44.9d,
+          any = true,
+          anyRef = "wah",
+          intMap = Map(1 -> 1),
+          longMap = Map(2L -> 2L)
+        )
+      ))
+    }
+  }
+
+  class `A case class nested inside of an object` {
+    @Test def `is parsable from a JSON object` = {
+      parse[OuterObject.NestedCaseClass]("""{"id": 1}""").must(be(OuterObject.NestedCaseClass(1)))
+    }
+  }
+
+  class `A case class nested inside of an object nested inside of an object` {
+    @Test def `is parsable from a JSON object` = {
+      parse[OuterObject.InnerObject.SuperNestedCaseClass]("""{"id": 1}""").must(be(OuterObject.InnerObject.SuperNestedCaseClass(1)))
+    }
+  }
+
+  class `A case class with two constructors` {
+    @Test def `is parsable from a JSON object with the same parameters as the case accessor` = {
+      parse[CaseClassWithTwoConstructors]("""{"id":1,"name":"Bert"}""").must(be(CaseClassWithTwoConstructors(1, "Bert")))
+    }
+
+    @Test def `is parsable from a JSON object which works with the second constructor` = {
+      evaluating {
+        parse[CaseClassWithTwoConstructors]("""{"id":1}""")
+      }.must(throwA[ParsingException])
+    }
+  }
+
+  class `A case class with snake-cased fields` {
+    @Test def `is parsable from a snake-cased JSON object` = {
+      parse[CaseClassWithSnakeCase]("""{"one_thing":"yes","two_thing":"good"}""").must(be(CaseClassWithSnakeCase("yes", "good")))
+    }
+
+    @Test def `generates a snake-cased JSON object` = {
+      generate(CaseClassWithSnakeCase("yes", "good")).must(be("""{"one_thing":"yes","two_thing":"good"}"""))
+    }
+
+    @Test def `throws errors with the snake-cased field names present` = {
+      evaluating {
+        parse[CaseClassWithSnakeCase]("""{"one_thing":"yes"}""")
+      }.must(throwA[ParsingException]("Invalid JSON. Needed [one_thing, two_thing], but found [one_thing]."))
+    }
+  }
+
+  class `A case class with array members` {
+    @Test def `is parsable from a JSON object` = {
+      val c = parse[CaseClassWithArrays]("""{"one":"1","two":["a","b","c"],"three":[1,2,3]}""")
+
+      c.one.must(be("1"))
+      c.two.must(be(Array("a", "b", "c")))
+      c.three.must(be(Array(1, 2, 3)))
+    }
+
+    @Test def `generates a JSON object` = {
+      generate(CaseClassWithArrays("1", Array("a", "b", "c"), Array(1, 2, 3))).must(be(
+        """{"one":"1","two":["a","b","c"],"three":[1,2,3]}"""
+      ))
+    }
+  }
+}

--- a/src/test/scala/com/codahale/jerkson/tests/CollectionSupportSpec.scala
+++ b/src/test/scala/com/codahale/jerkson/tests/CollectionSupportSpec.scala
@@ -1,0 +1,177 @@
+package com.codahale.jerkson.tests
+
+import scala.collection._
+import com.codahale.jerkson.Json._
+import com.codahale.simplespec.Spec
+import org.junit.{Ignore, Test}
+
+class CollectionSupportSpec extends Spec {
+  class `A collection.BitSet` {
+    @Test def `generates a JSON array of ints` = {
+      generate(BitSet(1)).must(be("[1]"))
+    }
+
+    @Test def `is parsable from a JSON array of ints` = {
+      parse[BitSet]("[1,2,3]").must(be(BitSet(1, 2, 3)))
+    }
+  }
+
+  class `A collection.Iterator[Int]` {
+    @Test def `generates a JSON array of ints` = {
+      generate(Seq(1, 2, 3).iterator).must(be("[1,2,3]"))
+    }
+
+    @Test def `is parsable from a JSON array of ints` = {
+      parse[Iterator[Int]]("[1,2,3]").toList.must(be(List(1, 2, 3)))
+    }
+
+    @Test def `is parsable from an empty JSON array` = {
+      parse[Iterator[Int]]("[]").toList.must(be(List.empty[Int]))
+    }
+  }
+
+  class `A collection.Traversable[Int]` {
+    @Test def `generates a JSON array of ints` = {
+      generate(Seq(1, 2, 3).toTraversable).must(be("[1,2,3]"))
+    }
+
+    @Test def `is parsable from a JSON array of ints` = {
+      parse[Traversable[Int]]("[1,2,3]").toList.must(be(List(1, 2, 3)))
+    }
+
+    @Test def `is parsable from an empty JSON array` = {
+      parse[Traversable[Int]]("[]").toList.must(be(List.empty[Int]))
+    }
+  }
+
+  class `A collection.BufferedIterator[Int]` {
+    @Test def `generates a JSON array of ints` = {
+      generate(Seq(1, 2, 3).iterator.buffered).must(be("[1,2,3]"))
+    }
+
+    @Test def `is parsable from a JSON array of ints` = {
+      parse[BufferedIterator[Int]]("[1,2,3]").toList.must(be(List(1, 2, 3)))
+    }
+
+    @Test def `is parsable from an empty JSON array` = {
+      parse[BufferedIterator[Int]]("[]").toList.must(be(List.empty[Int]))
+    }
+  }
+
+  class `A collection.Iterable[Int]` {
+    @Test def `generates a JSON array of ints` = {
+      generate(Seq(1, 2, 3).toIterable).must(be("[1,2,3]"))
+    }
+
+    @Test def `is parsable from a JSON array of ints` = {
+      parse[Iterable[Int]]("[1,2,3]").toList.must(be(List(1, 2, 3)))
+    }
+
+    @Test def `is parsable from an empty JSON array` = {
+      parse[Iterable[Int]]("[]").toList.must(be(List.empty[Int]))
+    }
+  }
+
+  class `A collection.Set[Int]` {
+    @Test def `generates a JSON array of ints` = {
+      generate(Set(1, 2, 3)).must(be("[1,2,3]"))
+    }
+
+    @Test def `is parsable from a JSON array of ints` = {
+      parse[Set[Int]]("[1,2,3]").must(be(Set(1, 2, 3)))
+    }
+
+    @Test def `is parsable from an empty JSON array` = {
+      parse[Set[Int]]("[]").must(be(Set.empty[Int]))
+    }
+  }
+
+  class `A collection.Map[String, Int]` {
+    @Test def `generates a JSON object with int field values` = {
+      generate(Map("one" -> 1, "two" -> 2)).must(be("""{"one":1,"two":2}"""))
+    }
+
+    @Test def `is parsable from a JSON object with int field values` = {
+      parse[Map[String, Int]]("""{"one":1,"two":2}""").must(be(Map("one" -> 1, "two" -> 2)))
+    }
+
+    @Test def `is parsable from an empty JSON object` = {
+      parse[Map[String, Int]]("{}").must(be(Map.empty[String, Int]))
+    }
+  }
+
+  class `A collection.IndexedSeq[Int]` {
+    @Test def `generates a JSON array of ints` = {
+      generate(IndexedSeq(1, 2, 3)).must(be("[1,2,3]"))
+    }
+
+    @Test def `is parsable from a JSON array of ints` = {
+      parse[IndexedSeq[Int]]("[1,2,3]").must(be(IndexedSeq(1, 2, 3)))
+    }
+
+    @Test def `is parsable from an empty JSON array` = {
+      parse[IndexedSeq[Int]]("[]").must(be(IndexedSeq.empty))
+    }
+  }
+
+  class `A collection.Seq[Int]` {
+    @Test def `generates a JSON array of ints` = {
+      generate(Seq(1, 2, 3)).must(be("[1,2,3]"))
+    }
+
+    @Test def `is parsable from a JSON array of ints` = {
+      parse[Seq[Int]]("[1,2,3]").must(be(Seq(1, 2, 3)))
+    }
+
+    @Test def `is parsable from an empty JSON array` = {
+      parse[Seq[Int]]("[]").must(be(Seq.empty[Int]))
+    }
+  }
+
+  class `A collection.SortedMap[String, Int]` {
+    @Test def `generates a JSON object with int field values` = {
+      generate(SortedMap("one" -> 1, "two" -> 2)).must(be("""{"one":1,"two":2}"""))
+    }
+
+    // TODO: 6/1/11 <coda> -- figure out how to deserialize SortedMap instances
+
+    /**
+     * I think all this would take is a mapping from Class[_] to Ordering, which
+     * would need to have hard-coded the various primitive types, and then add
+     * support for Ordered and Comparable classes. Once we have the Ordering,
+     * we can pass it in manually to a builder.
+     */
+    
+    @Ignore @Test def `is parsable from a JSON object with int field values` = {
+      parse[SortedMap[String, Int]]("""{"one":1,"two":2}""").must(be(SortedMap("one" -> 1, "two" -> 2)))
+    }
+
+    @Ignore @Test def `is parsable from an empty JSON object` = {
+      parse[SortedMap[String, Int]]("{}").must(be(SortedMap.empty[String, Int]))
+    }
+  }
+
+  class `A collection.SortedSet[Int]` {
+    @Test def `generates a JSON array of ints` = {
+      generate(SortedSet(1, 2, 3)).must(be("[1,2,3]"))
+    }
+
+    // TODO: 6/1/11 <coda> -- figure out how to deserialize SortedMap instances
+
+    /**
+     * I think all this would take is a mapping from Class[_] to Ordering, which
+     * would need to have hard-coded the various primitive types, and then add
+     * support for Ordered and Comparable classes. Once we have the Ordering,
+     * we can pass it in manually to a builder.
+     */
+
+    @Ignore @Test def `is parsable from a JSON array of ints` = {
+      parse[SortedSet[Int]]("[1,2,3]").must(be(SortedSet(1, 2, 3)))
+
+    }
+
+    @Ignore @Test def `is parsable from an empty JSON array` = {
+      parse[SortedSet[Int]]("[]").must(be(SortedSet.empty[Int]))
+    }
+  }
+}

--- a/src/test/scala/com/codahale/jerkson/tests/CollectionSupportSpec.scala
+++ b/src/test/scala/com/codahale/jerkson/tests/CollectionSupportSpec.scala
@@ -2,176 +2,166 @@ package com.codahale.jerkson.tests
 
 import scala.collection._
 import com.codahale.jerkson.Json._
-import com.codahale.simplespec.Spec
-import org.junit.{Ignore, Test}
+import org.scalatest.FlatSpec
+import org.scalatest.Matchers
 
-class CollectionSupportSpec extends Spec {
-  class `A collection.BitSet` {
-    @Test def `generates a JSON array of ints` = {
-      generate(BitSet(1)).must(be("[1]"))
-    }
+class CollectionSupportSpec extends FlatSpec with Matchers {
 
-    @Test def `is parsable from a JSON array of ints` = {
-      parse[BitSet]("[1,2,3]").must(be(BitSet(1, 2, 3)))
-    }
+  behavior of "A collection.BitSet"
+  it should "generates a JSON array of ints" in {
+    generate(BitSet(1)) shouldBe "[1]"
   }
 
-  class `A collection.Iterator[Int]` {
-    @Test def `generates a JSON array of ints` = {
-      generate(Seq(1, 2, 3).iterator).must(be("[1,2,3]"))
-    }
-
-    @Test def `is parsable from a JSON array of ints` = {
-      parse[Iterator[Int]]("[1,2,3]").toList.must(be(List(1, 2, 3)))
-    }
-
-    @Test def `is parsable from an empty JSON array` = {
-      parse[Iterator[Int]]("[]").toList.must(be(List.empty[Int]))
-    }
+  it should "is parsable from a JSON array of ints" in {
+    parse[BitSet]("[1,2,3]") shouldBe BitSet(1, 2, 3)
   }
 
-  class `A collection.Traversable[Int]` {
-    @Test def `generates a JSON array of ints` = {
-      generate(Seq(1, 2, 3).toTraversable).must(be("[1,2,3]"))
-    }
-
-    @Test def `is parsable from a JSON array of ints` = {
-      parse[Traversable[Int]]("[1,2,3]").toList.must(be(List(1, 2, 3)))
-    }
-
-    @Test def `is parsable from an empty JSON array` = {
-      parse[Traversable[Int]]("[]").toList.must(be(List.empty[Int]))
-    }
+  behavior of "A collection.Iterator[Int]"
+  it should "generates a JSON array of ints" in {
+    generate(Seq(1, 2, 3).iterator) shouldBe "[1,2,3]"
   }
 
-  class `A collection.BufferedIterator[Int]` {
-    @Test def `generates a JSON array of ints` = {
-      generate(Seq(1, 2, 3).iterator.buffered).must(be("[1,2,3]"))
-    }
-
-    @Test def `is parsable from a JSON array of ints` = {
-      parse[BufferedIterator[Int]]("[1,2,3]").toList.must(be(List(1, 2, 3)))
-    }
-
-    @Test def `is parsable from an empty JSON array` = {
-      parse[BufferedIterator[Int]]("[]").toList.must(be(List.empty[Int]))
-    }
+  it should "is parsable from a JSON array of ints" in {
+    parse[Iterator[Int]]("[1,2,3]").toList shouldBe List(1, 2, 3)
   }
 
-  class `A collection.Iterable[Int]` {
-    @Test def `generates a JSON array of ints` = {
-      generate(Seq(1, 2, 3).toIterable).must(be("[1,2,3]"))
-    }
-
-    @Test def `is parsable from a JSON array of ints` = {
-      parse[Iterable[Int]]("[1,2,3]").toList.must(be(List(1, 2, 3)))
-    }
-
-    @Test def `is parsable from an empty JSON array` = {
-      parse[Iterable[Int]]("[]").toList.must(be(List.empty[Int]))
-    }
+  it should "is parsable from an empty JSON array" in {
+    parse[Iterator[Int]]("[]").toList shouldBe List.empty[Int]
   }
 
-  class `A collection.Set[Int]` {
-    @Test def `generates a JSON array of ints` = {
-      generate(Set(1, 2, 3)).must(be("[1,2,3]"))
-    }
-
-    @Test def `is parsable from a JSON array of ints` = {
-      parse[Set[Int]]("[1,2,3]").must(be(Set(1, 2, 3)))
-    }
-
-    @Test def `is parsable from an empty JSON array` = {
-      parse[Set[Int]]("[]").must(be(Set.empty[Int]))
-    }
+  behavior of "A collection.Traversable[Int]"
+  it should "generates a JSON array of ints" in {
+    generate(Seq(1, 2, 3).toTraversable) shouldBe "[1,2,3]"
   }
 
-  class `A collection.Map[String, Int]` {
-    @Test def `generates a JSON object with int field values` = {
-      generate(Map("one" -> 1, "two" -> 2)).must(be("""{"one":1,"two":2}"""))
-    }
-
-    @Test def `is parsable from a JSON object with int field values` = {
-      parse[Map[String, Int]]("""{"one":1,"two":2}""").must(be(Map("one" -> 1, "two" -> 2)))
-    }
-
-    @Test def `is parsable from an empty JSON object` = {
-      parse[Map[String, Int]]("{}").must(be(Map.empty[String, Int]))
-    }
+  it should "is parsable from a JSON array of ints" in {
+    parse[Traversable[Int]]("[1,2,3]").toList shouldBe List(1, 2, 3)
   }
 
-  class `A collection.IndexedSeq[Int]` {
-    @Test def `generates a JSON array of ints` = {
-      generate(IndexedSeq(1, 2, 3)).must(be("[1,2,3]"))
-    }
-
-    @Test def `is parsable from a JSON array of ints` = {
-      parse[IndexedSeq[Int]]("[1,2,3]").must(be(IndexedSeq(1, 2, 3)))
-    }
-
-    @Test def `is parsable from an empty JSON array` = {
-      parse[IndexedSeq[Int]]("[]").must(be(IndexedSeq.empty))
-    }
+  it should "is parsable from an empty JSON array" in {
+    parse[Traversable[Int]]("[]").toList shouldBe List.empty[Int]
   }
 
-  class `A collection.Seq[Int]` {
-    @Test def `generates a JSON array of ints` = {
-      generate(Seq(1, 2, 3)).must(be("[1,2,3]"))
-    }
-
-    @Test def `is parsable from a JSON array of ints` = {
-      parse[Seq[Int]]("[1,2,3]").must(be(Seq(1, 2, 3)))
-    }
-
-    @Test def `is parsable from an empty JSON array` = {
-      parse[Seq[Int]]("[]").must(be(Seq.empty[Int]))
-    }
+  behavior of "A collection.BufferedIterator[Int]"
+  it should "generates a JSON array of ints" in {
+    generate(Seq(1, 2, 3).iterator.buffered) shouldBe "[1,2,3]"
   }
 
-  class `A collection.SortedMap[String, Int]` {
-    @Test def `generates a JSON object with int field values` = {
-      generate(SortedMap("one" -> 1, "two" -> 2)).must(be("""{"one":1,"two":2}"""))
-    }
-
-    // TODO: 6/1/11 <coda> -- figure out how to deserialize SortedMap instances
-
-    /**
-     * I think all this would take is a mapping from Class[_] to Ordering, which
-     * would need to have hard-coded the various primitive types, and then add
-     * support for Ordered and Comparable classes. Once we have the Ordering,
-     * we can pass it in manually to a builder.
-     */
-    
-    @Ignore @Test def `is parsable from a JSON object with int field values` = {
-      parse[SortedMap[String, Int]]("""{"one":1,"two":2}""").must(be(SortedMap("one" -> 1, "two" -> 2)))
-    }
-
-    @Ignore @Test def `is parsable from an empty JSON object` = {
-      parse[SortedMap[String, Int]]("{}").must(be(SortedMap.empty[String, Int]))
-    }
+  it should "is parsable from a JSON array of ints" in {
+    parse[BufferedIterator[Int]]("[1,2,3]").toList shouldBe List(1, 2, 3)
   }
 
-  class `A collection.SortedSet[Int]` {
-    @Test def `generates a JSON array of ints` = {
-      generate(SortedSet(1, 2, 3)).must(be("[1,2,3]"))
-    }
+  it should "is parsable from an empty JSON array" in {
+    parse[BufferedIterator[Int]]("[]").toList shouldBe List.empty[Int]
+  }
 
-    // TODO: 6/1/11 <coda> -- figure out how to deserialize SortedMap instances
+  behavior of "A collection.Iterable[Int]"
+  it should "generates a JSON array of ints" in {
+    generate(Seq(1, 2, 3).toIterable) shouldBe "[1,2,3]"
+  }
 
-    /**
-     * I think all this would take is a mapping from Class[_] to Ordering, which
-     * would need to have hard-coded the various primitive types, and then add
-     * support for Ordered and Comparable classes. Once we have the Ordering,
-     * we can pass it in manually to a builder.
-     */
+  it should "is parsable from a JSON array of ints" in {
+    parse[Iterable[Int]]("[1,2,3]").toList shouldBe List(1, 2, 3)
+  }
 
-    @Ignore @Test def `is parsable from a JSON array of ints` = {
-      parse[SortedSet[Int]]("[1,2,3]").must(be(SortedSet(1, 2, 3)))
+  it should "is parsable from an empty JSON array" in {
+    parse[Iterable[Int]]("[]").toList shouldBe List.empty[Int]
+  }
 
-    }
+  behavior of "A collection.Set[Int]"
+  it should "generates a JSON array of ints" in {
+    generate(Set(1, 2, 3)) shouldBe "[1,2,3]"
+  }
 
-    @Ignore @Test def `is parsable from an empty JSON array` = {
-      parse[SortedSet[Int]]("[]").must(be(SortedSet.empty[Int]))
-    }
+  it should "is parsable from a JSON array of ints" in {
+    parse[Set[Int]]("[1,2,3]") shouldBe Set(1, 2, 3)
+  }
+
+  it should "is parsable from an empty JSON array" in {
+    parse[Set[Int]]("[]") shouldBe Set.empty[Int]
+  }
+
+  behavior of "A collection.Map[String, Int]"
+  it should "generates a JSON object with int field values" in {
+    generate(Map("one" -> 1, "two" -> 2)) shouldBe """{"one":1,"two":2}"""
+  }
+
+  it should "is parsable from a JSON object with int field values" in {
+    parse[Map[String, Int]]("""{"one":1,"two":2}""") shouldBe Map("one" -> 1, "two" -> 2)
+  }
+
+  it should "is parsable from an empty JSON object" in {
+    parse[Map[String, Int]]("{}") shouldBe Map.empty[String, Int]
+  }
+
+  behavior of "A collection.IndexedSeq[Int]"
+  it should "generates a JSON array of ints" in {
+    generate(IndexedSeq(1, 2, 3)) shouldBe "[1,2,3]"
+  }
+
+  it should "is parsable from a JSON array of ints" in {
+    parse[IndexedSeq[Int]]("[1,2,3]") shouldBe IndexedSeq(1, 2, 3)
+  }
+
+  it should "is parsable from an empty JSON array" in {
+    parse[IndexedSeq[Int]]("[]") shouldBe IndexedSeq.empty
+  }
+
+  behavior of "A collection.Seq[Int]"
+  it should "generates a JSON array of ints" in {
+    generate(Seq(1, 2, 3)) shouldBe "[1,2,3]"
+  }
+
+  it should "is parsable from a JSON array of ints" in {
+    parse[Seq[Int]]("[1,2,3]") shouldBe Seq(1, 2, 3)
+  }
+
+  it should "is parsable from an empty JSON array" in {
+    parse[Seq[Int]]("[]") shouldBe Seq.empty[Int]
+  }
+
+  behavior of "A collection.SortedMap[String, Int]"
+  it should "generates a JSON object with int field values" in {
+    generate(SortedMap("one" -> 1, "two" -> 2)) shouldBe """{"one":1,"two":2}"""
+  }
+
+  // TODO: 6/1/11 <coda> -- figure out how to deserialize SortedMap instances
+
+  /**
+    * I think all this would take is a mapping from Class[_] to Ordering, which
+    * would need to have hard-coded the various primitive types, and then add
+    * support for Ordered and Comparable classes. Once we have the Ordering,
+    * we can pass it in manually to a builder.
+    */
+
+  ignore should "is parsable from a JSON object with int field values" in {
+    parse[SortedMap[String, Int]]("""{"one":1,"two":2}""") shouldBe SortedMap("one" -> 1, "two" -> 2)
+  }
+
+  ignore should "is parsable from an empty JSON object" in {
+    parse[SortedMap[String, Int]]("{}") shouldBe SortedMap.empty[String, Int]
+  }
+
+  behavior of "A collection.SortedSet[Int]"
+  it should "generates a JSON array of ints" in {
+    generate(SortedSet(1, 2, 3)) shouldBe "[1,2,3]"
+  }
+
+  // TODO: 6/1/11 <coda> -- figure out how to deserialize SortedMap instances
+
+  /**
+    * I think all this would take is a mapping from Class[_] to Ordering, which
+    * would need to have hard-coded the various primitive types, and then add
+    * support for Ordered and Comparable classes. Once we have the Ordering,
+    * we can pass it in manually to a builder.
+    */
+
+  ignore should "is parsable from a JSON array of ints" in {
+    parse[SortedSet[Int]]("[1,2,3]") shouldBe SortedSet(1, 2, 3)
+
+  }
+
+  ignore should "is parsable from an empty JSON array" in {
+    parse[SortedSet[Int]]("[]") shouldBe SortedSet.empty[Int]
   }
 }

--- a/src/test/scala/com/codahale/jerkson/tests/DefaultCollectionSupportSpec.scala
+++ b/src/test/scala/com/codahale/jerkson/tests/DefaultCollectionSupportSpec.scala
@@ -1,0 +1,247 @@
+package com.codahale.jerkson.tests
+
+import com.codahale.jerkson.Json._
+import com.codahale.simplespec.Spec
+import com.codahale.jerkson.ParsingException
+import org.junit.{Ignore, Test}
+
+class DefaultCollectionSupportSpec extends Spec {
+  class `A Range` {
+    @Test def `generates a JSON object` = {
+      generate(Range.inclusive(1, 4, 3)).must(be("""{"start":1,"end":4,"step":3,"inclusive":true}"""))
+    }
+
+    @Test def `generates a JSON object without the inclusive field if it's exclusive` = {
+      generate(Range(1, 4, 3)).must(be("""{"start":1,"end":4,"step":3}"""))
+    }
+
+    @Test def `generates a JSON object without the step field if it's 1` = {
+      generate(Range(1, 4)).must(be("""{"start":1,"end":4}"""))
+    }
+
+    @Test def `is parsable from a JSON object` = {
+      parse[Range]("""{"start":1,"end":4,"step":3,"inclusive":true}""").must(be(Range.inclusive(1, 4, 3)))
+    }
+
+    @Test def `is parsable from a JSON object without the inclusive field` = {
+      parse[Range]("""{"start":1,"end":4,"step":3}""").must(be(Range(1, 4, 3)))
+    }
+
+    @Test def `is parsable from a JSON object without the step field` = {
+      parse[Range]("""{"start":1,"end":4}""").must(be(Range(1, 4)))
+    }
+
+    @Test def `is not parsable from a JSON object without the required fields` = {
+      evaluating {
+        parse[Range]("""{"start":1}""")
+      }.must(throwA[ParsingException]("""Invalid JSON. Needed [start, end, <step>, <inclusive>], but found [start]."""))
+    }
+
+  }
+
+  class `A Pair[Int]` {
+    @Ignore @Test def `generates a two-element JSON array of ints` = {
+      // TODO: 5/31/11 <coda> -- fix Pair serialization
+      generate(Pair(1, 2)).must(be("[1,2]"))
+    }
+
+    @Ignore @Test def `is parsable from a two-element JSON array of ints` = {
+      // TODO: 5/31/11 <coda> -- fix Pair deserialization
+      parse[Pair[Int, Int]]("[1,2]").must(be(Pair(1, 2)))
+    }
+  }
+
+  class `A Triple[Int]` {
+    @Ignore @Test def `generates a three-element JSON array of ints` = {
+      // TODO: 5/31/11 <coda> -- fix Triple serialization
+      generate(Triple(1, 2, 3)).must(be("[1,2,3]"))
+    }
+
+    @Ignore @Test def `is parsable from a three-element JSON array of ints` = {
+      // TODO: 5/31/11 <coda> -- fix Triple deserialization
+      parse[Triple[Int, Int, Int]]("[1,2,3]").must(be(Triple(1, 2, 3)))
+    }
+  }
+
+  class `A four-tuple` {
+    @Ignore @Test def `generates a four-element JSON array` = {
+      // TODO: 5/31/11 <coda> -- fix Tuple4 serialization
+      generate((1, "2", 3, "4")).must(be("[1,\"2\",3,\"4\"]"))
+    }
+
+    @Ignore @Test def `is parsable from a three-element JSON array of ints` = {
+      // TODO: 5/31/11 <coda> -- fix Tuple4 deserialization
+      parse[(Int, String, Int, String)]("[1,\"2\",3,\"4\"]").must(be((1, "2", 3, "4")))
+    }
+  }
+
+  // TODO: 6/1/11 <coda> -- add support for all Tuple1->TupleBillionty types
+
+  class `A Seq[Int]` {
+    @Test def `generates a JSON array of ints` = {
+      generate(Seq(1, 2, 3)).must(be("[1,2,3]"))
+    }
+
+    @Test def `is parsable from a JSON array of ints` = {
+      parse[Seq[Int]]("[1,2,3]").must(be(Seq(1, 2, 3)))
+    }
+
+    @Test def `is parsable from an empty JSON array` = {
+      parse[Seq[Int]]("[]").must(be(Seq.empty[Int]))
+    }
+  }
+
+  class `A List[Int]` {
+    @Test def `generates a JSON array of ints` = {
+      generate(List(1, 2, 3)).must(be("[1,2,3]"))
+    }
+
+    @Test def `is parsable from a JSON array of ints` = {
+      parse[List[Int]]("[1,2,3]").must(be(List(1, 2, 3)))
+    }
+
+    @Test def `is parsable from an empty JSON array` = {
+      parse[List[Int]]("[]").must(be(List.empty[Int]))
+    }
+  }
+
+  class `An IndexedSeq[Int]` {
+    @Test def `generates a JSON array of ints` = {
+      generate(IndexedSeq(1, 2, 3)).must(be("[1,2,3]"))
+    }
+
+    @Test def `is parsable from a JSON array of ints` = {
+      parse[IndexedSeq[Int]]("[1,2,3]").must(be(IndexedSeq(1, 2, 3)))
+    }
+
+    @Test def `is parsable from an empty JSON array` = {
+      parse[IndexedSeq[Int]]("[]").must(be(IndexedSeq.empty[Int]))
+    }
+  }
+
+  class `A Vector[Int]` {
+    @Test def `generates a JSON array of ints` = {
+      generate(Vector(1, 2, 3)).must(be("[1,2,3]"))
+    }
+
+    @Test def `is parsable from a JSON array of ints` = {
+      parse[Vector[Int]]("[1,2,3]").must(be(Vector(1, 2, 3)))
+    }
+
+    @Test def `is parsable from an empty JSON array` = {
+      parse[Vector[Int]]("[]").must(be(Vector.empty[Int]))
+    }
+  }
+
+  class `A Set[Int]` {
+    @Test def `generates a JSON array of ints` = {
+      generate(Set(1, 2, 3)).must(be("[1,2,3]"))
+    }
+
+    @Test def `is parsable from a JSON array of ints` = {
+      parse[Set[Int]]("[1,2,3]").must(be(Set(1, 2, 3)))
+    }
+
+    @Test def `is parsable from an empty JSON array` = {
+      parse[Set[Int]]("[]").must(be(Set.empty[Int]))
+    }
+  }
+
+  class `A Map[String, Int]` {
+    @Test def `generates a JSON object with int field values` = {
+      generate(Map("one" -> 1, "two" -> 2)).must(be("""{"one":1,"two":2}"""))
+    }
+
+    @Test def `is parsable from a JSON object with int field values` = {
+      parse[Map[String, Int]]("""{"one":1,"two":2}""").must(be(Map("one" -> 1, "two" -> 2)))
+    }
+
+    @Test def `is parsable from an empty JSON object` = {
+      parse[Map[String, Int]]("{}").must(be(Map.empty[String, Int]))
+    }
+  }
+
+  class `A Map[String, Any]` {
+    @Test def `generates a JSON object with mixed field values` = {
+      generate(Map("one" -> 1, "two" -> "2")).must(be("""{"one":1,"two":"2"}"""))
+    }
+
+    @Test def `is parsable from a JSON object with mixed field values` = {
+      parse[Map[String, Any]]("""{"one":1,"two":"2"}""").must(be(Map[String, Any]("one" -> 1, "two" -> "2")))
+    }
+
+    @Test def `is parsable from an empty JSON object` = {
+      parse[Map[String, Any]]("{}").must(be(Map.empty[String, Any]))
+    }
+  }
+
+  class `A Stream[Int]` {
+    @Test def `generates a JSON array` = {
+      generate(Stream(1, 2, 3)).must(be("[1,2,3]"))
+    }
+
+    @Test def `is parsable from a JSON array of ints` = {
+      parse[Stream[Int]]("[1,2,3]").must(be(Stream(1, 2, 3)))
+    }
+
+    @Test def `is parsable from an empty JSON array` = {
+      parse[Stream[Int]]("[]").must(be(Stream.empty[Int]))
+    }
+  }
+
+  class `An Iterator[Int]` {
+    @Test def `generates a JSON array of ints` = {
+      generate(Seq(1, 2, 3).iterator).must(be("[1,2,3]"))
+    }
+
+    @Test def `is parsable from a JSON array of ints` = {
+      parse[Iterator[Int]]("[1,2,3]").toList.must(be(List(1, 2, 3)))
+    }
+
+    @Test def `is parsable from an empty JSON array` = {
+      parse[Iterator[Int]]("[]").toList.must(be(List.empty[Int]))
+    }
+  }
+
+  class `A Traversable[Int]` {
+    @Test def `generates a JSON array of ints` = {
+      generate(Seq(1, 2, 3).toTraversable).must(be("[1,2,3]"))
+    }
+
+    @Test def `is parsable from a JSON array of ints` = {
+      parse[Traversable[Int]]("[1,2,3]").toList.must(be(List(1, 2, 3)))
+    }
+
+    @Test def `is parsable from an empty JSON array` = {
+      parse[Traversable[Int]]("[]").toList.must(be(List.empty[Int]))
+    }
+  }
+
+  class `A BufferedIterator[Int]` {
+    @Test def `generates a JSON array of ints` = {
+      generate(Seq(1, 2, 3).iterator.buffered).must(be("[1,2,3]"))
+    }
+
+    @Test def `is parsable from a JSON array of ints` = {
+      parse[BufferedIterator[Int]]("[1,2,3]").toList.must(be(List(1, 2, 3)))
+    }
+
+    @Test def `is parsable from an empty JSON array` = {
+      parse[BufferedIterator[Int]]("[]").toList.must(be(List.empty[Int]))
+    }
+  }
+
+  class `An Iterable[Int]` {
+    @Test def `generates a JSON array of ints` = {
+      generate(Seq(1, 2, 3).toIterable).must(be("[1,2,3]"))
+    }
+
+    @Test def `is parsable from a JSON array of ints` = {
+      parse[Iterable[Int]]("[1,2,3]").toList.must(be(List(1, 2, 3)))
+    }
+
+    @Test def `is parsable from an empty JSON array` = {
+      parse[Iterable[Int]]("[]").toList.must(be(List.empty[Int]))
+    }
+  }
+}

--- a/src/test/scala/com/codahale/jerkson/tests/DefaultCollectionSupportSpec.scala
+++ b/src/test/scala/com/codahale/jerkson/tests/DefaultCollectionSupportSpec.scala
@@ -1,247 +1,229 @@
 package com.codahale.jerkson.tests
 
 import com.codahale.jerkson.Json._
-import com.codahale.simplespec.Spec
 import com.codahale.jerkson.ParsingException
-import org.junit.{Ignore, Test}
+import org.scalatest.FlatSpec
+import org.scalatest.Matchers
 
-class DefaultCollectionSupportSpec extends Spec {
-  class `A Range` {
-    @Test def `generates a JSON object` = {
-      generate(Range.inclusive(1, 4, 3)).must(be("""{"start":1,"end":4,"step":3,"inclusive":true}"""))
-    }
-
-    @Test def `generates a JSON object without the inclusive field if it's exclusive` = {
-      generate(Range(1, 4, 3)).must(be("""{"start":1,"end":4,"step":3}"""))
-    }
-
-    @Test def `generates a JSON object without the step field if it's 1` = {
-      generate(Range(1, 4)).must(be("""{"start":1,"end":4}"""))
-    }
-
-    @Test def `is parsable from a JSON object` = {
-      parse[Range]("""{"start":1,"end":4,"step":3,"inclusive":true}""").must(be(Range.inclusive(1, 4, 3)))
-    }
-
-    @Test def `is parsable from a JSON object without the inclusive field` = {
-      parse[Range]("""{"start":1,"end":4,"step":3}""").must(be(Range(1, 4, 3)))
-    }
-
-    @Test def `is parsable from a JSON object without the step field` = {
-      parse[Range]("""{"start":1,"end":4}""").must(be(Range(1, 4)))
-    }
-
-    @Test def `is not parsable from a JSON object without the required fields` = {
-      evaluating {
-        parse[Range]("""{"start":1}""")
-      }.must(throwA[ParsingException]("""Invalid JSON. Needed [start, end, <step>, <inclusive>], but found [start]."""))
-    }
-
+class DefaultCollectionSupportSpec extends FlatSpec with Matchers {
+  behavior of "A Range"
+  it should "generates a JSON object" in {
+    generate(Range.inclusive(1, 4, 3)) shouldBe """{"start":1,"end":4,"step":3,"inclusive":true}"""
   }
 
-  class `A Pair[Int]` {
-    @Ignore @Test def `generates a two-element JSON array of ints` = {
-      // TODO: 5/31/11 <coda> -- fix Pair serialization
-      generate(Pair(1, 2)).must(be("[1,2]"))
-    }
-
-    @Ignore @Test def `is parsable from a two-element JSON array of ints` = {
-      // TODO: 5/31/11 <coda> -- fix Pair deserialization
-      parse[Pair[Int, Int]]("[1,2]").must(be(Pair(1, 2)))
-    }
+  it should "generates a JSON object without the inclusive field if it's exclusive" in {
+    generate(Range(1, 4, 3)) shouldBe """{"start":1,"end":4,"step":3}"""
   }
 
-  class `A Triple[Int]` {
-    @Ignore @Test def `generates a three-element JSON array of ints` = {
-      // TODO: 5/31/11 <coda> -- fix Triple serialization
-      generate(Triple(1, 2, 3)).must(be("[1,2,3]"))
-    }
-
-    @Ignore @Test def `is parsable from a three-element JSON array of ints` = {
-      // TODO: 5/31/11 <coda> -- fix Triple deserialization
-      parse[Triple[Int, Int, Int]]("[1,2,3]").must(be(Triple(1, 2, 3)))
-    }
+  it should "generates a JSON object without the step field if it's 1" in {
+    generate(Range(1, 4)) shouldBe """{"start":1,"end":4}"""
   }
 
-  class `A four-tuple` {
-    @Ignore @Test def `generates a four-element JSON array` = {
-      // TODO: 5/31/11 <coda> -- fix Tuple4 serialization
-      generate((1, "2", 3, "4")).must(be("[1,\"2\",3,\"4\"]"))
-    }
+  it should "is parsable from a JSON object" in {
+    parse[Range]("""{"start":1,"end":4,"step":3,"inclusive":true}""") shouldBe Range.inclusive(1, 4, 3)
+  }
 
-    @Ignore @Test def `is parsable from a three-element JSON array of ints` = {
-      // TODO: 5/31/11 <coda> -- fix Tuple4 deserialization
-      parse[(Int, String, Int, String)]("[1,\"2\",3,\"4\"]").must(be((1, "2", 3, "4")))
-    }
+  it should "is parsable from a JSON object without the inclusive field" in {
+    parse[Range]("""{"start":1,"end":4,"step":3}""") shouldBe Range(1, 4, 3)
+  }
+
+  it should "is parsable from a JSON object without the step field" in {
+    parse[Range]("""{"start":1,"end":4}""") shouldBe Range(1, 4)
+  }
+
+  it should "is not parsable from a JSON object without the required fields" in {
+    the [ParsingException] thrownBy parse[Range]("""{"start":1}""") should have message "Invalid JSON. Needed [start, end, <step>, <inclusive>], but found [start]."
+  }
+
+
+  behavior of "A Pair[Int]"
+  ignore should "generates a two-element JSON array of ints" in {
+    // TODO: 5/31/11 <coda> -- fix Pair serialization
+    generate(Pair(1, 2)) shouldBe "[1,2]"
+  }
+
+  ignore should "is parsable from a two-element JSON array of ints" in {
+    // TODO: 5/31/11 <coda> -- fix Pair deserialization
+    parse[Pair[Int, Int]]("[1,2]") shouldBe Pair(1, 2)
+  }
+
+  behavior of "A Triple[Int]"
+  ignore should "generates a three-element JSON array of ints" in {
+    // TODO: 5/31/11 <coda> -- fix Triple serialization
+    generate(Triple(1, 2, 3)) shouldBe "[1,2,3]"
+  }
+
+  ignore should "is parsable from a three-element JSON array of ints" in {
+    // TODO: 5/31/11 <coda> -- fix Triple deserialization
+    parse[Triple[Int, Int, Int]]("[1,2,3]") shouldBe Triple(1, 2, 3)
+  }
+
+  behavior of "A four-tuple"
+  ignore should "generates a four-element JSON array" in {
+    // TODO: 5/31/11 <coda> -- fix Tuple4 serialization
+    generate((1, "2", 3, "4")) shouldBe "[1,\"2\",3,\"4\"]"
+  }
+
+  ignore should "is parsable from a three-element JSON array of ints" in {
+    // TODO: 5/31/11 <coda> -- fix Tuple4 deserialization
+    parse[(Int, String, Int, String)]("[1,\"2\",3,\"4\"]") shouldBe (1, "2", 3, "4")
   }
 
   // TODO: 6/1/11 <coda> -- add support for all Tuple1->TupleBillionty types
 
-  class `A Seq[Int]` {
-    @Test def `generates a JSON array of ints` = {
-      generate(Seq(1, 2, 3)).must(be("[1,2,3]"))
-    }
-
-    @Test def `is parsable from a JSON array of ints` = {
-      parse[Seq[Int]]("[1,2,3]").must(be(Seq(1, 2, 3)))
-    }
-
-    @Test def `is parsable from an empty JSON array` = {
-      parse[Seq[Int]]("[]").must(be(Seq.empty[Int]))
-    }
+  behavior of "A Seq[Int]"
+  it should "generates a JSON array of ints" in {
+    generate(Seq(1, 2, 3)) shouldBe "[1,2,3]"
   }
 
-  class `A List[Int]` {
-    @Test def `generates a JSON array of ints` = {
-      generate(List(1, 2, 3)).must(be("[1,2,3]"))
-    }
-
-    @Test def `is parsable from a JSON array of ints` = {
-      parse[List[Int]]("[1,2,3]").must(be(List(1, 2, 3)))
-    }
-
-    @Test def `is parsable from an empty JSON array` = {
-      parse[List[Int]]("[]").must(be(List.empty[Int]))
-    }
+  it should "is parsable from a JSON array of ints" in {
+    parse[Seq[Int]]("[1,2,3]") shouldBe Seq(1, 2, 3)
   }
 
-  class `An IndexedSeq[Int]` {
-    @Test def `generates a JSON array of ints` = {
-      generate(IndexedSeq(1, 2, 3)).must(be("[1,2,3]"))
-    }
-
-    @Test def `is parsable from a JSON array of ints` = {
-      parse[IndexedSeq[Int]]("[1,2,3]").must(be(IndexedSeq(1, 2, 3)))
-    }
-
-    @Test def `is parsable from an empty JSON array` = {
-      parse[IndexedSeq[Int]]("[]").must(be(IndexedSeq.empty[Int]))
-    }
+  it should "is parsable from an empty JSON array" in {
+    parse[Seq[Int]]("[]") shouldBe Seq.empty[Int]
   }
 
-  class `A Vector[Int]` {
-    @Test def `generates a JSON array of ints` = {
-      generate(Vector(1, 2, 3)).must(be("[1,2,3]"))
-    }
-
-    @Test def `is parsable from a JSON array of ints` = {
-      parse[Vector[Int]]("[1,2,3]").must(be(Vector(1, 2, 3)))
-    }
-
-    @Test def `is parsable from an empty JSON array` = {
-      parse[Vector[Int]]("[]").must(be(Vector.empty[Int]))
-    }
+  behavior of "A List[Int]"
+  it should "generates a JSON array of ints" in {
+    generate(List(1, 2, 3)) shouldBe "[1,2,3]"
   }
 
-  class `A Set[Int]` {
-    @Test def `generates a JSON array of ints` = {
-      generate(Set(1, 2, 3)).must(be("[1,2,3]"))
-    }
-
-    @Test def `is parsable from a JSON array of ints` = {
-      parse[Set[Int]]("[1,2,3]").must(be(Set(1, 2, 3)))
-    }
-
-    @Test def `is parsable from an empty JSON array` = {
-      parse[Set[Int]]("[]").must(be(Set.empty[Int]))
-    }
+  it should "is parsable from a JSON array of ints" in {
+    parse[List[Int]]("[1,2,3]") shouldBe List(1, 2, 3)
   }
 
-  class `A Map[String, Int]` {
-    @Test def `generates a JSON object with int field values` = {
-      generate(Map("one" -> 1, "two" -> 2)).must(be("""{"one":1,"two":2}"""))
-    }
-
-    @Test def `is parsable from a JSON object with int field values` = {
-      parse[Map[String, Int]]("""{"one":1,"two":2}""").must(be(Map("one" -> 1, "two" -> 2)))
-    }
-
-    @Test def `is parsable from an empty JSON object` = {
-      parse[Map[String, Int]]("{}").must(be(Map.empty[String, Int]))
-    }
+  it should "is parsable from an empty JSON array" in {
+    parse[List[Int]]("[]") shouldBe List.empty[Int]
   }
 
-  class `A Map[String, Any]` {
-    @Test def `generates a JSON object with mixed field values` = {
-      generate(Map("one" -> 1, "two" -> "2")).must(be("""{"one":1,"two":"2"}"""))
-    }
-
-    @Test def `is parsable from a JSON object with mixed field values` = {
-      parse[Map[String, Any]]("""{"one":1,"two":"2"}""").must(be(Map[String, Any]("one" -> 1, "two" -> "2")))
-    }
-
-    @Test def `is parsable from an empty JSON object` = {
-      parse[Map[String, Any]]("{}").must(be(Map.empty[String, Any]))
-    }
+  behavior of "An IndexedSeq[Int]"
+  it should "generates a JSON array of ints" in {
+    generate(IndexedSeq(1, 2, 3)) shouldBe "[1,2,3]"
   }
 
-  class `A Stream[Int]` {
-    @Test def `generates a JSON array` = {
-      generate(Stream(1, 2, 3)).must(be("[1,2,3]"))
-    }
-
-    @Test def `is parsable from a JSON array of ints` = {
-      parse[Stream[Int]]("[1,2,3]").must(be(Stream(1, 2, 3)))
-    }
-
-    @Test def `is parsable from an empty JSON array` = {
-      parse[Stream[Int]]("[]").must(be(Stream.empty[Int]))
-    }
+  it should "is parsable from a JSON array of ints" in {
+    parse[IndexedSeq[Int]]("[1,2,3]") shouldBe IndexedSeq(1, 2, 3)
   }
 
-  class `An Iterator[Int]` {
-    @Test def `generates a JSON array of ints` = {
-      generate(Seq(1, 2, 3).iterator).must(be("[1,2,3]"))
-    }
-
-    @Test def `is parsable from a JSON array of ints` = {
-      parse[Iterator[Int]]("[1,2,3]").toList.must(be(List(1, 2, 3)))
-    }
-
-    @Test def `is parsable from an empty JSON array` = {
-      parse[Iterator[Int]]("[]").toList.must(be(List.empty[Int]))
-    }
+  it should "is parsable from an empty JSON array" in {
+    parse[IndexedSeq[Int]]("[]") shouldBe IndexedSeq.empty[Int]
   }
 
-  class `A Traversable[Int]` {
-    @Test def `generates a JSON array of ints` = {
-      generate(Seq(1, 2, 3).toTraversable).must(be("[1,2,3]"))
-    }
-
-    @Test def `is parsable from a JSON array of ints` = {
-      parse[Traversable[Int]]("[1,2,3]").toList.must(be(List(1, 2, 3)))
-    }
-
-    @Test def `is parsable from an empty JSON array` = {
-      parse[Traversable[Int]]("[]").toList.must(be(List.empty[Int]))
-    }
+  behavior of "A Vector[Int]"
+  it should "generates a JSON array of ints" in {
+    generate(Vector(1, 2, 3)) shouldBe "[1,2,3]"
   }
 
-  class `A BufferedIterator[Int]` {
-    @Test def `generates a JSON array of ints` = {
-      generate(Seq(1, 2, 3).iterator.buffered).must(be("[1,2,3]"))
-    }
-
-    @Test def `is parsable from a JSON array of ints` = {
-      parse[BufferedIterator[Int]]("[1,2,3]").toList.must(be(List(1, 2, 3)))
-    }
-
-    @Test def `is parsable from an empty JSON array` = {
-      parse[BufferedIterator[Int]]("[]").toList.must(be(List.empty[Int]))
-    }
+  it should "is parsable from a JSON array of ints" in {
+    parse[Vector[Int]]("[1,2,3]") shouldBe Vector(1, 2, 3)
   }
 
-  class `An Iterable[Int]` {
-    @Test def `generates a JSON array of ints` = {
-      generate(Seq(1, 2, 3).toIterable).must(be("[1,2,3]"))
-    }
+  it should "is parsable from an empty JSON array" in {
+    parse[Vector[Int]]("[]") shouldBe Vector.empty[Int]
+  }
 
-    @Test def `is parsable from a JSON array of ints` = {
-      parse[Iterable[Int]]("[1,2,3]").toList.must(be(List(1, 2, 3)))
-    }
+  behavior of "A Set[Int]"
+  it should "generates a JSON array of ints" in {
+    generate(Set(1, 2, 3)) shouldBe "[1,2,3]"
+  }
 
-    @Test def `is parsable from an empty JSON array` = {
-      parse[Iterable[Int]]("[]").toList.must(be(List.empty[Int]))
-    }
+  it should "is parsable from a JSON array of ints" in {
+    parse[Set[Int]]("[1,2,3]") shouldBe Set(1, 2, 3)
+  }
+
+  it should "is parsable from an empty JSON array" in {
+    parse[Set[Int]]("[]") shouldBe Set.empty[Int]
+  }
+
+  behavior of "A Map[String, Int]"
+  it should "generates a JSON object with int field values" in {
+    generate(Map("one" -> 1, "two" -> 2)) shouldBe """{"one":1,"two":2}"""
+  }
+
+  it should "is parsable from a JSON object with int field values" in {
+    parse[Map[String, Int]]("""{"one":1,"two":2}""") shouldBe Map("one" -> 1, "two" -> 2)
+  }
+
+  it should "is parsable from an empty JSON object" in {
+    parse[Map[String, Int]]("{}") shouldBe Map.empty[String, Int]
+  }
+
+  behavior of "A Map[String, Any]"
+  it should "generates a JSON object with mixed field values" in {
+    generate(Map("one" -> 1, "two" -> "2")) shouldBe """{"one":1,"two":"2"}"""
+  }
+
+  it should "is parsable from a JSON object with mixed field values" in {
+    parse[Map[String, Any]]("""{"one":1,"two":"2"}""") shouldBe Map[String, Any]("one" -> 1, "two" -> "2")
+  }
+
+  it should "is parsable from an empty JSON object" in {
+    parse[Map[String, Any]]("{}") shouldBe Map.empty[String, Any]
+  }
+
+  behavior of "A Stream[Int]"
+  it should "generates a JSON array" in {
+    generate(Stream(1, 2, 3)) shouldBe "[1,2,3]"
+  }
+
+  it should "is parsable from a JSON array of ints" in {
+    parse[Stream[Int]]("[1,2,3]") shouldBe Stream(1, 2, 3)
+  }
+
+  it should "is parsable from an empty JSON array" in {
+    parse[Stream[Int]]("[]") shouldBe Stream.empty[Int]
+  }
+
+  behavior of "An Iterator[Int]"
+  it should "generates a JSON array of ints" in {
+    generate(Seq(1, 2, 3).iterator) shouldBe "[1,2,3]"
+  }
+
+  it should "is parsable from a JSON array of ints" in {
+    parse[Iterator[Int]]("[1,2,3]").toList shouldBe List(1, 2, 3)
+  }
+
+  it should "is parsable from an empty JSON array" in {
+    parse[Iterator[Int]]("[]").toList shouldBe List.empty[Int]
+  }
+
+  behavior of "A Traversable[Int]"
+  it should "generates a JSON array of ints" in {
+    generate(Seq(1, 2, 3).toTraversable) shouldBe "[1,2,3]"
+  }
+
+  it should "is parsable from a JSON array of ints" in {
+    parse[Traversable[Int]]("[1,2,3]").toList shouldBe List(1, 2, 3)
+  }
+
+  it should "is parsable from an empty JSON array" in {
+    parse[Traversable[Int]]("[]").toList shouldBe List.empty[Int]
+  }
+
+  behavior of "A BufferedIterator[Int]"
+  it should "generates a JSON array of ints" in {
+    generate(Seq(1, 2, 3).iterator.buffered) shouldBe "[1,2,3]"
+  }
+
+  it should "is parsable from a JSON array of ints" in {
+    parse[BufferedIterator[Int]]("[1,2,3]").toList shouldBe List(1, 2, 3)
+  }
+
+  it should "is parsable from an empty JSON array" in {
+    parse[BufferedIterator[Int]]("[]").toList shouldBe List.empty[Int]
+  }
+
+  behavior of "An Iterable[Int]"
+  it should "generates a JSON array of ints" in {
+    generate(Seq(1, 2, 3).toIterable) shouldBe "[1,2,3]"
+  }
+
+  it should "is parsable from a JSON array of ints" in {
+    parse[Iterable[Int]]("[1,2,3]").toList shouldBe List(1, 2, 3)
+  }
+
+  it should "is parsable from an empty JSON array" in {
+    parse[Iterable[Int]]("[]").toList shouldBe List.empty[Int]
   }
 }

--- a/src/test/scala/com/codahale/jerkson/tests/EdgeCaseSpec.scala
+++ b/src/test/scala/com/codahale/jerkson/tests/EdgeCaseSpec.scala
@@ -1,0 +1,69 @@
+package com.codahale.jerkson.tests
+
+import com.codahale.jerkson.Json._
+import com.codahale.simplespec.Spec
+import com.codahale.jerkson.ParsingException
+import java.io.ByteArrayInputStream
+import org.junit.Test
+
+class EdgeCaseSpec extends Spec {
+  class `Deserializing lists` {
+    @Test def `doesn't cache Seq builders` = {
+      parse[List[Int]]("[1,2,3,4]").must(be(List(1, 2, 3, 4)))
+      parse[List[Int]]("[1,2,3,4]").must(be(List(1, 2, 3, 4)))
+    }
+  }
+
+  class `Parsing a JSON array of ints with nulls` {
+    @Test def `should be readable as a List[Option[Int]]` = {
+      parse[List[Option[Int]]]("[1,2,null,4]").must(be(List(Some(1), Some(2), None, Some(4))))
+    }
+  }
+
+  class `Deserializing maps` {
+    @Test def `doesn't cache Map builders` = {
+      parse[Map[String, Int]](""" {"one":1, "two": 2} """).must(be(Map("one" -> 1, "two" -> 2)))
+      parse[Map[String, Int]](""" {"one":1, "two": 2} """).must(be(Map("one" -> 1, "two" -> 2)))
+    }
+  }
+
+  class `Parsing malformed JSON` {
+    @Test def `should throw a ParsingException with an informative message` = {
+      evaluating {
+        parse[Boolean]("jjf8;09")
+      }.must(throwA[ParsingException](
+            "Malformed JSON. Unexpected character ('j' (code 106)): expected a " +
+                    "valid value (number, String, array, object, 'true', 'false' " +
+                    "or 'null') at character offset 0."))
+
+      evaluating {
+        parse[CaseClass]("{\"ye\":1")
+      }.must(throwA[ParsingException](
+            "Malformed JSON. Unexpected end-of-input: expected close marker for " +
+                    "OBJECT at character offset 20."))
+    }
+  }
+
+  class `Parsing invalid JSON` {
+    @Test def `should throw a ParsingException with an informative message` = {
+      evaluating {
+        parse[CaseClass]("900")
+      }.must(throwA[ParsingException](
+        ("""Can not deserialize instance of com.codahale.jerkson.tests.CaseClass out of VALUE_NUMBER_INT token\n""" +
+          """ at \[Source: java.io.StringReader@[0-9a-f]+; line: 1, column: 1\]""").r))
+
+      evaluating {
+        parse[CaseClass]("{\"woo\": 1}")
+      }.must(throwA[ParsingException]("Invalid JSON. Needed [id, name], but found [woo]."))
+    }
+  }
+
+  class `Parsing an empty document` {
+    @Test def `should throw a ParsingException with an informative message` = {
+      val input = new ByteArrayInputStream(Array.empty)
+      evaluating {
+        parse[CaseClass](input)
+      }.must(throwA[ParsingException]("""No content to map due to end\-of\-input""".r))
+    }
+  }
+}

--- a/src/test/scala/com/codahale/jerkson/tests/EdgeCaseSpec.scala
+++ b/src/test/scala/com/codahale/jerkson/tests/EdgeCaseSpec.scala
@@ -1,69 +1,53 @@
 package com.codahale.jerkson.tests
 
 import com.codahale.jerkson.Json._
-import com.codahale.simplespec.Spec
 import com.codahale.jerkson.ParsingException
 import java.io.ByteArrayInputStream
-import org.junit.Test
+import org.scalatest.FlatSpec
+import org.scalatest.Matchers
 
-class EdgeCaseSpec extends Spec {
-  class `Deserializing lists` {
-    @Test def `doesn't cache Seq builders` = {
-      parse[List[Int]]("[1,2,3,4]").must(be(List(1, 2, 3, 4)))
-      parse[List[Int]]("[1,2,3,4]").must(be(List(1, 2, 3, 4)))
-    }
+class EdgeCaseSpec extends FlatSpec with Matchers {
+  behavior of "Deserializing lists"
+  it should "doesn't cache Seq builders" in {
+    parse[List[Int]]("[1,2,3,4]") shouldBe List(1, 2, 3, 4)
+    parse[List[Int]]("[1,2,3,4]") shouldBe List(1, 2, 3, 4)
   }
 
-  class `Parsing a JSON array of ints with nulls` {
-    @Test def `should be readable as a List[Option[Int]]` = {
-      parse[List[Option[Int]]]("[1,2,null,4]").must(be(List(Some(1), Some(2), None, Some(4))))
-    }
+  behavior of "Parsing a JSON array of ints with nulls"
+  it should "should be readable as a List[Option[Int]]" in {
+    parse[List[Option[Int]]]("[1,2,null,4]") shouldBe List(Some(1), Some(2), None, Some(4))
   }
 
-  class `Deserializing maps` {
-    @Test def `doesn't cache Map builders` = {
-      parse[Map[String, Int]](""" {"one":1, "two": 2} """).must(be(Map("one" -> 1, "two" -> 2)))
-      parse[Map[String, Int]](""" {"one":1, "two": 2} """).must(be(Map("one" -> 1, "two" -> 2)))
-    }
+  behavior of "Deserializing maps"
+  it should "doesn't cache Map builders" in {
+    parse[Map[String, Int]](""" {"one":1, "two": 2} """) shouldBe Map("one" -> 1, "two" -> 2)
+    parse[Map[String, Int]](""" {"one":1, "two": 2} """) shouldBe Map("one" -> 1, "two" -> 2)
   }
 
-  class `Parsing malformed JSON` {
-    @Test def `should throw a ParsingException with an informative message` = {
-      evaluating {
-        parse[Boolean]("jjf8;09")
-      }.must(throwA[ParsingException](
-            "Malformed JSON. Unexpected character ('j' (code 106)): expected a " +
-                    "valid value (number, String, array, object, 'true', 'false' " +
-                    "or 'null') at character offset 0."))
+  behavior of "Parsing malformed JSON"
+  it should "should throw a ParsingException with an informative message" in {
+    the [ParsingException] thrownBy parse[Boolean]("jjf8;09") should have message
+    "Malformed JSON. Unrecognized token 'jjf8': was expecting ('true', 'false' or 'null') at character offset 4."
 
-      evaluating {
-        parse[CaseClass]("{\"ye\":1")
-      }.must(throwA[ParsingException](
-            "Malformed JSON. Unexpected end-of-input: expected close marker for " +
-                    "OBJECT at character offset 20."))
-    }
+    the [ParsingException] thrownBy parse[CaseClass]("{\"ye\":1") should have message
+    "Malformed JSON. Unexpected end-of-input: expected close marker for " +
+    "OBJECT at character offset 21."
   }
 
-  class `Parsing invalid JSON` {
-    @Test def `should throw a ParsingException with an informative message` = {
-      evaluating {
-        parse[CaseClass]("900")
-      }.must(throwA[ParsingException](
-        ("""Can not deserialize instance of com.codahale.jerkson.tests.CaseClass out of VALUE_NUMBER_INT token\n""" +
-          """ at \[Source: java.io.StringReader@[0-9a-f]+; line: 1, column: 1\]""").r))
+  behavior of "Parsing invalid JSON"
+  it should "should throw a ParsingException with an informative message" in {
+    val thrown = the [ParsingException] thrownBy parse[CaseClass]("900")
+    thrown.getMessage should fullyMatch
+      ("""Can not deserialize instance of com.codahale.jerkson.tests.CaseClass out of VALUE_NUMBER_INT token\n""" +
+        """ at \[Source: java.io.StringReader@[0-9a-f]+; line: 1, column: 1\]""").r
 
-      evaluating {
-        parse[CaseClass]("{\"woo\": 1}")
-      }.must(throwA[ParsingException]("Invalid JSON. Needed [id, name], but found [woo]."))
-    }
+    the [ParsingException] thrownBy parse[CaseClass]("{\"woo\": 1}") should have message "Invalid JSON. Needed [id, name], but found [woo]."
   }
 
-  class `Parsing an empty document` {
-    @Test def `should throw a ParsingException with an informative message` = {
-      val input = new ByteArrayInputStream(Array.empty)
-      evaluating {
-        parse[CaseClass](input)
-      }.must(throwA[ParsingException]("""No content to map due to end\-of\-input""".r))
-    }
+  behavior of "Parsing an empty document"
+  it should "should throw a ParsingException with an informative message" in {
+    val input = new ByteArrayInputStream(Array.empty)
+    val thrown = the [ParsingException] thrownBy parse[CaseClass](input)
+    thrown.getMessage should startWith("No content to map due to end-of-input")
   }
 }

--- a/src/test/scala/com/codahale/jerkson/tests/ExampleCaseClasses.scala
+++ b/src/test/scala/com/codahale/jerkson/tests/ExampleCaseClasses.scala
@@ -1,0 +1,74 @@
+package com.codahale.jerkson.tests
+
+import com.fasterxml.jackson.databind.JsonNode
+import com.fasterxml.jackson.annotation.{JsonIgnoreProperties, JsonIgnore}
+import com.codahale.jerkson.JsonSnakeCase
+
+case class CaseClass(id: Long, name: String)
+
+case class CaseClassWithLazyVal(id: Long) {
+  lazy val woo = "yeah"
+}
+
+case class CaseClassWithIgnoredField(id: Long) {
+  @JsonIgnore
+  val uncomfortable = "Bad Touch"
+}
+
+@JsonIgnoreProperties(Array("uncomfortable", "unpleasant"))
+case class CaseClassWithIgnoredFields(id: Long) {
+  val uncomfortable = "Bad Touch"
+  val unpleasant = "The Creeps"
+}
+
+case class CaseClassWithTransientField(id: Long) {
+  @transient
+  val lol = "I'm sure it's just a phase."
+}
+
+case class CaseClassWithOverloadedField(id: Long) {
+  def id(prefix: String): String = prefix + id
+}
+
+case class CaseClassWithOption(value: Option[String])
+
+case class CaseClassWithJsonNode(value: JsonNode)
+
+case class CaseClassWithAllTypes(map: Map[String, String],
+                                 set: Set[Int],
+                                 string: String,
+                                 list: List[Int],
+                                 seq: Seq[Int],
+                                 indexedSeq: IndexedSeq[Int],
+                                 vector: Vector[Int],
+                                 bigDecimal: BigDecimal,
+                                 bigInt: BigInt,
+                                 int: Int,
+                                 long: Long,
+                                 char: Char,
+                                 bool: Boolean,
+                                 short: Short,
+                                 byte: Byte,
+                                 float: Float,
+                                 double: Double,
+                                 any: Any,
+                                 anyRef: AnyRef,
+                                 intMap: Map[Int, Int],
+                                 longMap: Map[Long, Long])
+
+object OuterObject {
+  case class NestedCaseClass(id: Long)
+
+  object InnerObject {
+    case class SuperNestedCaseClass(id: Long)
+  }
+}
+
+case class CaseClassWithTwoConstructors(id: Long,  name: String) {
+  def this(id: Long) = this(id,  "New User")
+}
+
+@JsonSnakeCase
+case class CaseClassWithSnakeCase(oneThing: String, twoThing: String)
+
+case class CaseClassWithArrays(one: String, two: Array[String], three: Array[Int])

--- a/src/test/scala/com/codahale/jerkson/tests/FancyTypeSupportSpec.scala
+++ b/src/test/scala/com/codahale/jerkson/tests/FancyTypeSupportSpec.scala
@@ -1,0 +1,31 @@
+package com.codahale.jerkson.tests
+
+import java.net.URI
+import com.codahale.simplespec.Spec
+import org.junit.Test
+import com.codahale.jerkson.Json._
+import java.util.UUID
+
+class FancyTypeSupportSpec extends Spec {
+  class `A URI` {
+    @Test def `generates a JSON string` = {
+      generate(new URI("http://example.com/resource?query=yes")).must(be("\"http://example.com/resource?query=yes\""))
+    }
+
+    @Test def `is parsable from a JSON string` = {
+      parse[URI]("\"http://example.com/resource?query=yes\"").must(be(new URI("http://example.com/resource?query=yes")))
+    }
+  }
+
+  class `A UUID` {
+    val uuid = UUID.fromString("a62047e4-bfb5-4d71-aad7-1a6b338eee63")
+
+    @Test def `generates a JSON string` = {
+      generate(uuid).must(be("\"a62047e4-bfb5-4d71-aad7-1a6b338eee63\""))
+    }
+
+    @Test def `is parsable from a JSON string` = {
+      parse[UUID]("\"a62047e4-bfb5-4d71-aad7-1a6b338eee63\"").must(be(uuid))
+    }
+  }
+}

--- a/src/test/scala/com/codahale/jerkson/tests/FancyTypeSupportSpec.scala
+++ b/src/test/scala/com/codahale/jerkson/tests/FancyTypeSupportSpec.scala
@@ -1,31 +1,30 @@
 package com.codahale.jerkson.tests
 
 import java.net.URI
-import com.codahale.simplespec.Spec
-import org.junit.Test
 import com.codahale.jerkson.Json._
 import java.util.UUID
+import org.scalatest.FlatSpec
+import org.scalatest.Matchers
 
-class FancyTypeSupportSpec extends Spec {
-  class `A URI` {
-    @Test def `generates a JSON string` = {
-      generate(new URI("http://example.com/resource?query=yes")).must(be("\"http://example.com/resource?query=yes\""))
-    }
-
-    @Test def `is parsable from a JSON string` = {
-      parse[URI]("\"http://example.com/resource?query=yes\"").must(be(new URI("http://example.com/resource?query=yes")))
-    }
+class FancyTypeSupportSpec extends FlatSpec with Matchers {
+  behavior of "A URI"
+  it should "generates a JSON string" in {
+    generate(new URI("http://example.com/resource?query=yes")) shouldBe "\"http://example.com/resource?query=yes\""
   }
 
-  class `A UUID` {
-    val uuid = UUID.fromString("a62047e4-bfb5-4d71-aad7-1a6b338eee63")
+  it should "is parsable from a JSON string" in {
+    parse[URI]("\"http://example.com/resource?query=yes\"") shouldBe new URI("http://example.com/resource?query=yes")
+  }
 
-    @Test def `generates a JSON string` = {
-      generate(uuid).must(be("\"a62047e4-bfb5-4d71-aad7-1a6b338eee63\""))
-    }
 
-    @Test def `is parsable from a JSON string` = {
-      parse[UUID]("\"a62047e4-bfb5-4d71-aad7-1a6b338eee63\"").must(be(uuid))
-    }
+  behavior of "A UUID"
+  val uuid = UUID.fromString("a62047e4-bfb5-4d71-aad7-1a6b338eee63")
+
+  it should "generates a JSON string" in {
+    generate(uuid) shouldBe "\"a62047e4-bfb5-4d71-aad7-1a6b338eee63\""
+  }
+
+  it should "is parsable from a JSON string" in {
+    parse[UUID]("\"a62047e4-bfb5-4d71-aad7-1a6b338eee63\"") shouldBe uuid
   }
 }

--- a/src/test/scala/com/codahale/jerkson/tests/ImmutableCollectionSupportSpec.scala
+++ b/src/test/scala/com/codahale/jerkson/tests/ImmutableCollectionSupportSpec.scala
@@ -1,285 +1,249 @@
 package com.codahale.jerkson.tests
 
-import com.codahale.simplespec.Spec
 import com.codahale.jerkson.Json._
-import scala.collection.immutable._
 import com.codahale.jerkson.ParsingException
-import org.junit.{Ignore, Test}
+import org.scalatest.FlatSpec
+import org.scalatest.Matchers
+import scala.collection.immutable._
 
-class ImmutableCollectionSupportSpec extends Spec {
-  class `An immutable.Seq[Int]` {
-    @Test def `generates a JSON array of ints` = {
-      generate(Seq(1, 2, 3)).must(be("[1,2,3]"))
-    }
-
-    @Test def `is parsable from a JSON array of ints` = {
-      parse[Seq[Int]]("[1,2,3]").must(be(Seq(1, 2, 3)))
-    }
-
-    @Test def `is parsable from an empty JSON array` = {
-      parse[Seq[Int]]("[]").must(be(Seq.empty[Int]))
-    }
+class ImmutableCollectionSupportSpec extends FlatSpec with Matchers {
+  behavior of "An immutable.Seq[Int]"
+  it should "generates a JSON array of ints" in {
+    generate(Seq(1, 2, 3)) shouldBe "[1,2,3]"
   }
 
-  class `An immutable.List[Int]` {
-    @Test def `generates a JSON array of ints` = {
-      generate(List(1, 2, 3)).must(be("[1,2,3]"))
-    }
-
-    @Test def `is parsable from a JSON array of ints` = {
-      parse[List[Int]]("[1,2,3]").must(be(List(1, 2, 3)))
-    }
-
-    @Test def `is parsable from an empty JSON array` = {
-      parse[List[Int]]("[]").must(be(List.empty[Int]))
-    }
+  it should "is parsable from a JSON array of ints" in {
+    parse[Seq[Int]]("[1,2,3]") shouldBe Seq(1, 2, 3)
   }
 
-  class `An immutable.IndexedSeq[Int]` {
-    @Test def `generates a JSON array of ints` = {
-      generate(IndexedSeq(1, 2, 3)).must(be("[1,2,3]"))
-    }
-
-    @Test def `is parsable from a JSON array of ints` = {
-      parse[IndexedSeq[Int]]("[1,2,3]").must(be(IndexedSeq(1, 2, 3)))
-    }
-
-    @Test def `is parsable from an empty JSON array` = {
-      parse[IndexedSeq[Int]]("[]").must(be(IndexedSeq.empty[Int]))
-    }
+  it should "is parsable from an empty JSON array" in {
+    parse[Seq[Int]]("[]") shouldBe Seq.empty[Int]
   }
 
-  class `An immutable.TreeSet[Int]` {
-    @Test def `generates a JSON array` = {
-      generate(TreeSet(1)).must(be("[1]"))
-    }
-
-    // TODO: 6/1/11 <coda> -- figure out how to deserialize TreeSet instances
-
-    /**
-     * I think all this would take is a mapping from Class[_] to Ordering, which
-     * would need to have hard-coded the various primitive types, and then add
-     * support for Ordered and Comparable classes. Once we have the Ordering,
-     * we can pass it in manually to a builder.
-     */
-    
-    @Ignore @Test def `is parsable from a JSON array of ints` = {
-      parse[TreeSet[Int]]("[1,2,3]").must(be(TreeSet(1, 2, 3)))
-    }
-
-    @Ignore @Test def `is parsable from an empty JSON array` = {
-      parse[TreeSet[Int]]("[]").must(be(TreeSet.empty[Int]))
-    }
+  behavior of "An immutable.List[Int]"
+  it should "generates a JSON array of ints" in {
+    generate(List(1, 2, 3)) shouldBe "[1,2,3]"
   }
 
-  class `An immutable.HashSet[Int]` {
-    @Test def `generates a JSON array` = {
-      generate(HashSet(1)).must(be("[1]"))
-    }
-
-    @Test def `is parsable from a JSON array of ints` = {
-      parse[HashSet[Int]]("[1,2,3]").must(be(HashSet(1, 2, 3)))
-    }
-
-    @Test def `is parsable from an empty JSON array` = {
-      parse[HashSet[Int]]("[]").must(be(HashSet.empty[Int]))
-    }
+  it should "is parsable from a JSON array of ints" in {
+    parse[List[Int]]("[1,2,3]") shouldBe List(1, 2, 3)
   }
 
-  class `An immutable.BitSet` {
-    @Test def `generates a JSON array` = {
-      generate(BitSet(1)).must(be("[1]"))
-    }
-
-    @Test def `is parsable from a JSON array of ints` = {
-      parse[BitSet]("[1,2,3]").must(be(BitSet(1, 2, 3)))
-    }
-
-    @Test def `is parsable from an empty JSON array` = {
-      parse[BitSet]("[]").must(be(BitSet.empty))
-    }
+  it should "is parsable from an empty JSON array" in {
+    parse[List[Int]]("[]") shouldBe List.empty[Int]
   }
 
-  class `An immutable.TreeMap[String, Int]` {
-    @Test def `generates a JSON object` = {
-      generate(TreeMap("one" -> 1)).must(be("""{"one":1}"""))
-    }
-
-    // TODO: 6/1/11 <coda> -- figure out how to deserialize TreeMap instances
-
-    /**
-     * I think all this would take is a mapping from Class[_] to Ordering, which
-     * would need to have hard-coded the various primitive types, and then add
-     * support for Ordered and Comparable classes. Once we have the Ordering,
-     * we can pass it in manually to a builder.
-     */
-    
-    @Ignore @Test def `is parsable from a JSON object with int field values` = {
-      parse[TreeMap[String, Int]]("""{"one":1}""").must(be(TreeMap("one" -> 1)))
-    }
-
-    @Ignore @Test def `is parsable from an empty JSON object` = {
-      parse[TreeMap[String, Int]]("{}").must(be(TreeMap.empty[String, Int]))
-    }
+  behavior of "An immutable.IndexedSeq[Int]"
+  it should "generates a JSON array of ints" in {
+    generate(IndexedSeq(1, 2, 3)) shouldBe "[1,2,3]"
   }
 
-  class `An immutable.HashMap[String, Int]` {
-    @Test def `generates a JSON object` = {
-      generate(HashMap("one" -> 1)).must(be("""{"one":1}"""))
-    }
-
-    @Test def `is parsable from a JSON object with int field values` = {
-      parse[HashMap[String, Int]]("""{"one":1}""").must(be(HashMap("one" -> 1)))
-    }
-
-    @Test def `is parsable from an empty JSON object` = {
-      parse[HashMap[String, Int]]("{}").must(be(HashMap.empty[String, Int]))
-    }
+  it should "is parsable from a JSON array of ints" in {
+    parse[IndexedSeq[Int]]("[1,2,3]") shouldBe IndexedSeq(1, 2, 3)
   }
 
-  class `An immutable.HashMap[String, Any]` {
-    @Test def `generates a JSON object` = {
-      generate(HashMap[String, Any]("one" -> 1)).must(be("""{"one":1}"""))
-    }
-
-    @Test def `is parsable from a JSON object with int field values` = {
-      parse[HashMap[String, Any]]("""{"one":1}""").must(be(HashMap("one" -> 1)))
-    }
-
-    @Test def `is parsable from an empty JSON object` = {
-      parse[HashMap[String, Any]]("{}").must(be(HashMap.empty[String, Any]))
-    }
-
-    @Test def `is not parsable from an empty JSON object in a JSON array` = {
-      evaluating {
-        parse[HashMap[String, Any]]("[{}]")
-      }.must(throwA[ParsingException])
-    }
+  it should "is parsable from an empty JSON array" in {
+    parse[IndexedSeq[Int]]("[]") shouldBe IndexedSeq.empty[Int]
   }
 
-  class `An immutable.Map[Int, String]` {
-    @Test def `generates a JSON object` = {
-      generate(Map(1 -> "one")).must(be("""{"1":"one"}"""))
-    }
-
-    @Test def `is parsable from a JSON object with decimal field names and string field values` = {
-      parse[Map[Int, String]]("""{"1":"one"}""").must(be(Map(1 -> "one")))
-    }
-
-    @Test def `is not parsable from a JSON object with non-decimal field names` = {
-      evaluating {
-        parse[Map[Int, String]]("""{"one":"one"}""")
-      }.must(throwA[ParsingException])
-    }
-
-    @Test def `is parsable from an empty JSON object` = {
-      parse[Map[Int, String]]("{}").must(be(Map.empty[Int, String]))
-    }
+  behavior of "An immutable.TreeSet[Int]"
+  it should "generates a JSON array" in {
+    generate(TreeSet(1)) shouldBe "[1]"
   }
 
-  class `An immutable.Map[Int, Any]` {
-    @Test def `is not parsable from an empty JSON object in a JSON array` = {
-      evaluating {
-        parse[Map[Int, Any]]("[{}]")
-      }.must(throwA[ParsingException])
-    }
+  // TODO: 6/1/11 <coda> -- figure out how to deserialize TreeSet instances
+
+  /**
+    * I think all this would take is a mapping from Class[_] to Ordering, which
+    * would need to have hard-coded the various primitive types, and then add
+    * support for Ordered and Comparable classes. Once we have the Ordering,
+    * we can pass it in manually to a builder.
+    */
+  
+  ignore should "is parsable from a JSON array of ints" in {
+    parse[TreeSet[Int]]("[1,2,3]") shouldBe TreeSet(1, 2, 3)
   }
 
-  class `An immutable.IntMap[Any]` {
-    @Test def `is not parsable from an empty JSON object in a JSON array` = {
-      evaluating {
-        parse[IntMap[Any]]("[{}]")
-      }.must(throwA[ParsingException])
-    }
+  ignore should "is parsable from an empty JSON array" in {
+    parse[TreeSet[Int]]("[]") shouldBe TreeSet.empty[Int]
   }
 
-  class `An immutable.LongMap[Any]` {
-    @Test def `is not parsable from an empty JSON object in a JSON array` = {
-      evaluating {
-        parse[LongMap[Any]]("[{}]")
-      }.must(throwA[ParsingException])
-    }
+  behavior of "An immutable.HashSet[Int]"
+  it should "generates a JSON array" in {
+    generate(HashSet(1)) shouldBe "[1]"
   }
 
-  class `An immutable.Map[Long, Any]` {
-    @Test def `is not parsable from an empty JSON object in a JSON array` = {
-      evaluating {
-        parse[Map[Long, Any]]("[{}]")
-      }.must(throwA[ParsingException])
-    }
+  it should "is parsable from a JSON array of ints" in {
+    parse[HashSet[Int]]("[1,2,3]") shouldBe HashSet(1, 2, 3)
   }
 
-  class `An immutable.Map[Long, String]` {
-    @Test def `generates a JSON object` = {
-      generate(Map(1L -> "one")).must(be("""{"1":"one"}"""))
-    }
-
-    @Test def `is parsable from a JSON object with decimal field names and string field values` = {
-      parse[Map[Long, String]]("""{"1":"one"}""").must(be(Map(1L -> "one")))
-    }
-
-    @Test def `is not parsable from a JSON object with non-decimal field names` = {
-      evaluating {
-        parse[Map[Long, String]]("""{"one":"one"}""")
-      }.must(throwA[ParsingException])
-    }
-
-    @Test def `is parsable from an empty JSON object` = {
-      parse[Map[Long, String]]("{}").must(be(Map.empty[Long, String]))
-    }
+  it should "is parsable from an empty JSON array" in {
+    parse[HashSet[Int]]("[]") shouldBe HashSet.empty[Int]
   }
 
-  class `An immutable.IntMap[String]` {
-    @Test def `generates a JSON object` = {
-      generate(IntMap(1 -> "one")).must(be("""{"1":"one"}"""))
-    }
-
-    @Test def `is parsable from a JSON object with decimal field names and string field values` = {
-      parse[IntMap[String]]("""{"1":"one"}""").must(be(IntMap(1 -> "one")))
-    }
-
-    @Test def `is not parsable from a JSON object with non-decimal field names` = {
-      evaluating {
-        parse[IntMap[String]]("""{"one":"one"}""")
-      }.must(throwA[ParsingException])
-    }
-
-    @Test def `is parsable from an empty JSON object` = {
-      parse[IntMap[String]]("{}").must(be(IntMap.empty[String]))
-    }
+  behavior of "An immutable.BitSet"
+  it should "generates a JSON array" in {
+    generate(BitSet(1)) shouldBe "[1]"
   }
 
-  class `An immutable.LongMap[String]` {
-    @Test def `generates a JSON object` = {
-      generate(LongMap(1L -> "one")).must(be("""{"1":"one"}"""))
-    }
-
-    @Test def `is parsable from a JSON object with int field names and string field values` = {
-      parse[LongMap[String]]("""{"1":"one"}""").must(be(LongMap(1L -> "one")))
-    }
-
-    @Test def `is not parsable from a JSON object with non-decimal field names` = {
-      evaluating {
-        parse[LongMap[String]]("""{"one":"one"}""")
-      }.must(throwA[ParsingException])
-    }
-
-    @Test def `is parsable from an empty JSON object` = {
-      parse[LongMap[String]]("{}").must(be(LongMap.empty))
-    }
+  it should "is parsable from a JSON array of ints" in {
+    parse[BitSet]("[1,2,3]") shouldBe BitSet(1, 2, 3)
   }
 
-  class `An immutable.Queue[Int]` {
-    @Test def `generates a JSON array` = {
-      generate(Queue(1, 2, 3)).must(be("[1,2,3]"))
-    }
+  it should "is parsable from an empty JSON array" in {
+    parse[BitSet]("[]") shouldBe BitSet.empty
+  }
 
-    @Test def `is parsable from a JSON array of ints` = {
-      parse[Queue[Int]]("[1,2,3]").must(be(Queue(1, 2, 3)))
-    }
+  behavior of "An immutable.TreeMap[String, Int]"
+  it should "generates a JSON object" in {
+    generate(TreeMap("one" -> 1)) shouldBe """{"one":1}"""
+  }
 
-    @Test def `is parsable from an empty JSON array` = {
-      parse[Queue[Int]]("[]").must(be(Queue.empty))
-    }
+  // TODO: 6/1/11 <coda> -- figure out how to deserialize TreeMap instances
+
+  /**
+    * I think all this would take is a mapping from Class[_] to Ordering, which
+    * would need to have hard-coded the various primitive types, and then add
+    * support for Ordered and Comparable classes. Once we have the Ordering,
+    * we can pass it in manually to a builder.
+    */
+  
+  ignore should "is parsable from a JSON object with int field values" in {
+    parse[TreeMap[String, Int]]("""{"one":1}""") shouldBe TreeMap("one" -> 1)
+  }
+
+  ignore should "is parsable from an empty JSON object" in {
+    parse[TreeMap[String, Int]]("{}") shouldBe TreeMap.empty[String, Int]
+  }
+
+  behavior of "An immutable.HashMap[String, Int]"
+  it should "generates a JSON object" in {
+    generate(HashMap("one" -> 1)) shouldBe """{"one":1}"""
+  }
+
+  it should "is parsable from a JSON object with int field values" in {
+    parse[HashMap[String, Int]]("""{"one":1}""") shouldBe HashMap("one" -> 1)
+  }
+
+  it should "is parsable from an empty JSON object" in {
+    parse[HashMap[String, Int]]("{}") shouldBe HashMap.empty[String, Int]
+  }
+
+  behavior of "An immutable.HashMap[String, Any]"
+  it should "generates a JSON object" in {
+    generate(HashMap[String, Any]("one" -> 1)) shouldBe """{"one":1}"""
+  }
+
+  it should "is parsable from a JSON object with int field values" in {
+    parse[HashMap[String, Any]]("""{"one":1}""") shouldBe HashMap("one" -> 1)
+  }
+
+  it should "is parsable from an empty JSON object" in {
+    parse[HashMap[String, Any]]("{}") shouldBe HashMap.empty[String, Any]
+  }
+
+  it should "is not parsable from an empty JSON object in a JSON array" in {
+    a [ParsingException] should be thrownBy parse[HashMap[String, Any]]("[{}]")
+  }
+
+  behavior of "An immutable.Map[Int, String]"
+  it should "generates a JSON object" in {
+    generate(Map(1 -> "one")) shouldBe """{"1":"one"}"""
+  }
+
+  it should "is parsable from a JSON object with decimal field names and string field values" in {
+    parse[Map[Int, String]]("""{"1":"one"}""") shouldBe Map(1 -> "one")
+  }
+
+  it should "is not parsable from a JSON object with non-decimal field names" in {
+    a [ParsingException] should be thrownBy parse[Map[Int, String]]("""{"one":"one"}""")
+  }
+
+  it should "is parsable from an empty JSON object" in {
+    parse[Map[Int, String]]("{}") shouldBe Map.empty[Int, String]
+  }
+
+  behavior of "An immutable.Map[Int, Any]"
+  it should "is not parsable from an empty JSON object in a JSON array" in {
+    a [ParsingException] should be thrownBy parse[Map[Int, Any]]("[{}]")
+  }
+
+  behavior of "An immutable.IntMap[Any]"
+  it should "is not parsable from an empty JSON object in a JSON array" in {
+    a [ParsingException] should be thrownBy parse[IntMap[Any]]("[{}]")
+  }
+
+  behavior of "An immutable.LongMap[Any]"
+  it should "is not parsable from an empty JSON object in a JSON array" in {
+    a [ParsingException] should be thrownBy parse[LongMap[Any]]("[{}]")
+  }
+
+  behavior of "An immutable.Map[Long, Any]"
+  it should "is not parsable from an empty JSON object in a JSON array" in {
+    a [ParsingException] should be thrownBy parse[Map[Long, Any]]("[{}]")
+  }
+
+  behavior of "An immutable.Map[Long, String]"
+  it should "generates a JSON object" in {
+    generate(Map(1L -> "one")) shouldBe """{"1":"one"}"""
+  }
+
+  it should "is parsable from a JSON object with decimal field names and string field values" in {
+    parse[Map[Long, String]]("""{"1":"one"}""") shouldBe Map(1L -> "one")
+  }
+
+  it should "is not parsable from a JSON object with non-decimal field names" in {
+    a [ParsingException] should be thrownBy parse[Map[Long, String]]("""{"one":"one"}""")
+  }
+
+  it should "is parsable from an empty JSON object" in {
+    parse[Map[Long, String]]("{}") shouldBe Map.empty[Long, String]
+  }
+
+  behavior of "An immutable.IntMap[String]"
+  it should "generates a JSON object" in {
+    generate(IntMap(1 -> "one")) shouldBe """{"1":"one"}"""
+  }
+
+  it should "is parsable from a JSON object with decimal field names and string field values" in {
+    parse[IntMap[String]]("""{"1":"one"}""") shouldBe IntMap(1 -> "one")
+  }
+
+  it should "is not parsable from a JSON object with non-decimal field names" in {
+    a [ParsingException] should be thrownBy parse[IntMap[String]]("""{"one":"one"}""")
+  }
+
+  it should "is parsable from an empty JSON object" in {
+    parse[IntMap[String]]("{}") shouldBe IntMap.empty[String]
+  }
+
+  behavior of "An immutable.LongMap[String]"
+  it should "generates a JSON object" in {
+    generate(LongMap(1L -> "one")) shouldBe """{"1":"one"}"""
+  }
+
+  it should "is parsable from a JSON object with int field names and string field values" in {
+    parse[LongMap[String]]("""{"1":"one"}""") shouldBe LongMap(1L -> "one")
+  }
+
+  it should "is not parsable from a JSON object with non-decimal field names" in {
+    a [ParsingException] should be thrownBy parse[LongMap[String]]("""{"one":"one"}""")
+  }
+
+  it should "is parsable from an empty JSON object" in {
+    parse[LongMap[String]]("{}") shouldBe LongMap.empty
+  }
+
+  behavior of "An immutable.Queue[Int]"
+  it should "generates a JSON array" in {
+    generate(Queue(1, 2, 3)) shouldBe "[1,2,3]"
+  }
+
+  it should "is parsable from a JSON array of ints" in {
+    parse[Queue[Int]]("[1,2,3]") shouldBe Queue(1, 2, 3)
+  }
+
+  it should "is parsable from an empty JSON array" in {
+    parse[Queue[Int]]("[]") shouldBe Queue.empty
   }
 }

--- a/src/test/scala/com/codahale/jerkson/tests/ImmutableCollectionSupportSpec.scala
+++ b/src/test/scala/com/codahale/jerkson/tests/ImmutableCollectionSupportSpec.scala
@@ -1,0 +1,285 @@
+package com.codahale.jerkson.tests
+
+import com.codahale.simplespec.Spec
+import com.codahale.jerkson.Json._
+import scala.collection.immutable._
+import com.codahale.jerkson.ParsingException
+import org.junit.{Ignore, Test}
+
+class ImmutableCollectionSupportSpec extends Spec {
+  class `An immutable.Seq[Int]` {
+    @Test def `generates a JSON array of ints` = {
+      generate(Seq(1, 2, 3)).must(be("[1,2,3]"))
+    }
+
+    @Test def `is parsable from a JSON array of ints` = {
+      parse[Seq[Int]]("[1,2,3]").must(be(Seq(1, 2, 3)))
+    }
+
+    @Test def `is parsable from an empty JSON array` = {
+      parse[Seq[Int]]("[]").must(be(Seq.empty[Int]))
+    }
+  }
+
+  class `An immutable.List[Int]` {
+    @Test def `generates a JSON array of ints` = {
+      generate(List(1, 2, 3)).must(be("[1,2,3]"))
+    }
+
+    @Test def `is parsable from a JSON array of ints` = {
+      parse[List[Int]]("[1,2,3]").must(be(List(1, 2, 3)))
+    }
+
+    @Test def `is parsable from an empty JSON array` = {
+      parse[List[Int]]("[]").must(be(List.empty[Int]))
+    }
+  }
+
+  class `An immutable.IndexedSeq[Int]` {
+    @Test def `generates a JSON array of ints` = {
+      generate(IndexedSeq(1, 2, 3)).must(be("[1,2,3]"))
+    }
+
+    @Test def `is parsable from a JSON array of ints` = {
+      parse[IndexedSeq[Int]]("[1,2,3]").must(be(IndexedSeq(1, 2, 3)))
+    }
+
+    @Test def `is parsable from an empty JSON array` = {
+      parse[IndexedSeq[Int]]("[]").must(be(IndexedSeq.empty[Int]))
+    }
+  }
+
+  class `An immutable.TreeSet[Int]` {
+    @Test def `generates a JSON array` = {
+      generate(TreeSet(1)).must(be("[1]"))
+    }
+
+    // TODO: 6/1/11 <coda> -- figure out how to deserialize TreeSet instances
+
+    /**
+     * I think all this would take is a mapping from Class[_] to Ordering, which
+     * would need to have hard-coded the various primitive types, and then add
+     * support for Ordered and Comparable classes. Once we have the Ordering,
+     * we can pass it in manually to a builder.
+     */
+    
+    @Ignore @Test def `is parsable from a JSON array of ints` = {
+      parse[TreeSet[Int]]("[1,2,3]").must(be(TreeSet(1, 2, 3)))
+    }
+
+    @Ignore @Test def `is parsable from an empty JSON array` = {
+      parse[TreeSet[Int]]("[]").must(be(TreeSet.empty[Int]))
+    }
+  }
+
+  class `An immutable.HashSet[Int]` {
+    @Test def `generates a JSON array` = {
+      generate(HashSet(1)).must(be("[1]"))
+    }
+
+    @Test def `is parsable from a JSON array of ints` = {
+      parse[HashSet[Int]]("[1,2,3]").must(be(HashSet(1, 2, 3)))
+    }
+
+    @Test def `is parsable from an empty JSON array` = {
+      parse[HashSet[Int]]("[]").must(be(HashSet.empty[Int]))
+    }
+  }
+
+  class `An immutable.BitSet` {
+    @Test def `generates a JSON array` = {
+      generate(BitSet(1)).must(be("[1]"))
+    }
+
+    @Test def `is parsable from a JSON array of ints` = {
+      parse[BitSet]("[1,2,3]").must(be(BitSet(1, 2, 3)))
+    }
+
+    @Test def `is parsable from an empty JSON array` = {
+      parse[BitSet]("[]").must(be(BitSet.empty))
+    }
+  }
+
+  class `An immutable.TreeMap[String, Int]` {
+    @Test def `generates a JSON object` = {
+      generate(TreeMap("one" -> 1)).must(be("""{"one":1}"""))
+    }
+
+    // TODO: 6/1/11 <coda> -- figure out how to deserialize TreeMap instances
+
+    /**
+     * I think all this would take is a mapping from Class[_] to Ordering, which
+     * would need to have hard-coded the various primitive types, and then add
+     * support for Ordered and Comparable classes. Once we have the Ordering,
+     * we can pass it in manually to a builder.
+     */
+    
+    @Ignore @Test def `is parsable from a JSON object with int field values` = {
+      parse[TreeMap[String, Int]]("""{"one":1}""").must(be(TreeMap("one" -> 1)))
+    }
+
+    @Ignore @Test def `is parsable from an empty JSON object` = {
+      parse[TreeMap[String, Int]]("{}").must(be(TreeMap.empty[String, Int]))
+    }
+  }
+
+  class `An immutable.HashMap[String, Int]` {
+    @Test def `generates a JSON object` = {
+      generate(HashMap("one" -> 1)).must(be("""{"one":1}"""))
+    }
+
+    @Test def `is parsable from a JSON object with int field values` = {
+      parse[HashMap[String, Int]]("""{"one":1}""").must(be(HashMap("one" -> 1)))
+    }
+
+    @Test def `is parsable from an empty JSON object` = {
+      parse[HashMap[String, Int]]("{}").must(be(HashMap.empty[String, Int]))
+    }
+  }
+
+  class `An immutable.HashMap[String, Any]` {
+    @Test def `generates a JSON object` = {
+      generate(HashMap[String, Any]("one" -> 1)).must(be("""{"one":1}"""))
+    }
+
+    @Test def `is parsable from a JSON object with int field values` = {
+      parse[HashMap[String, Any]]("""{"one":1}""").must(be(HashMap("one" -> 1)))
+    }
+
+    @Test def `is parsable from an empty JSON object` = {
+      parse[HashMap[String, Any]]("{}").must(be(HashMap.empty[String, Any]))
+    }
+
+    @Test def `is not parsable from an empty JSON object in a JSON array` = {
+      evaluating {
+        parse[HashMap[String, Any]]("[{}]")
+      }.must(throwA[ParsingException])
+    }
+  }
+
+  class `An immutable.Map[Int, String]` {
+    @Test def `generates a JSON object` = {
+      generate(Map(1 -> "one")).must(be("""{"1":"one"}"""))
+    }
+
+    @Test def `is parsable from a JSON object with decimal field names and string field values` = {
+      parse[Map[Int, String]]("""{"1":"one"}""").must(be(Map(1 -> "one")))
+    }
+
+    @Test def `is not parsable from a JSON object with non-decimal field names` = {
+      evaluating {
+        parse[Map[Int, String]]("""{"one":"one"}""")
+      }.must(throwA[ParsingException])
+    }
+
+    @Test def `is parsable from an empty JSON object` = {
+      parse[Map[Int, String]]("{}").must(be(Map.empty[Int, String]))
+    }
+  }
+
+  class `An immutable.Map[Int, Any]` {
+    @Test def `is not parsable from an empty JSON object in a JSON array` = {
+      evaluating {
+        parse[Map[Int, Any]]("[{}]")
+      }.must(throwA[ParsingException])
+    }
+  }
+
+  class `An immutable.IntMap[Any]` {
+    @Test def `is not parsable from an empty JSON object in a JSON array` = {
+      evaluating {
+        parse[IntMap[Any]]("[{}]")
+      }.must(throwA[ParsingException])
+    }
+  }
+
+  class `An immutable.LongMap[Any]` {
+    @Test def `is not parsable from an empty JSON object in a JSON array` = {
+      evaluating {
+        parse[LongMap[Any]]("[{}]")
+      }.must(throwA[ParsingException])
+    }
+  }
+
+  class `An immutable.Map[Long, Any]` {
+    @Test def `is not parsable from an empty JSON object in a JSON array` = {
+      evaluating {
+        parse[Map[Long, Any]]("[{}]")
+      }.must(throwA[ParsingException])
+    }
+  }
+
+  class `An immutable.Map[Long, String]` {
+    @Test def `generates a JSON object` = {
+      generate(Map(1L -> "one")).must(be("""{"1":"one"}"""))
+    }
+
+    @Test def `is parsable from a JSON object with decimal field names and string field values` = {
+      parse[Map[Long, String]]("""{"1":"one"}""").must(be(Map(1L -> "one")))
+    }
+
+    @Test def `is not parsable from a JSON object with non-decimal field names` = {
+      evaluating {
+        parse[Map[Long, String]]("""{"one":"one"}""")
+      }.must(throwA[ParsingException])
+    }
+
+    @Test def `is parsable from an empty JSON object` = {
+      parse[Map[Long, String]]("{}").must(be(Map.empty[Long, String]))
+    }
+  }
+
+  class `An immutable.IntMap[String]` {
+    @Test def `generates a JSON object` = {
+      generate(IntMap(1 -> "one")).must(be("""{"1":"one"}"""))
+    }
+
+    @Test def `is parsable from a JSON object with decimal field names and string field values` = {
+      parse[IntMap[String]]("""{"1":"one"}""").must(be(IntMap(1 -> "one")))
+    }
+
+    @Test def `is not parsable from a JSON object with non-decimal field names` = {
+      evaluating {
+        parse[IntMap[String]]("""{"one":"one"}""")
+      }.must(throwA[ParsingException])
+    }
+
+    @Test def `is parsable from an empty JSON object` = {
+      parse[IntMap[String]]("{}").must(be(IntMap.empty[String]))
+    }
+  }
+
+  class `An immutable.LongMap[String]` {
+    @Test def `generates a JSON object` = {
+      generate(LongMap(1L -> "one")).must(be("""{"1":"one"}"""))
+    }
+
+    @Test def `is parsable from a JSON object with int field names and string field values` = {
+      parse[LongMap[String]]("""{"1":"one"}""").must(be(LongMap(1L -> "one")))
+    }
+
+    @Test def `is not parsable from a JSON object with non-decimal field names` = {
+      evaluating {
+        parse[LongMap[String]]("""{"one":"one"}""")
+      }.must(throwA[ParsingException])
+    }
+
+    @Test def `is parsable from an empty JSON object` = {
+      parse[LongMap[String]]("{}").must(be(LongMap.empty))
+    }
+  }
+
+  class `An immutable.Queue[Int]` {
+    @Test def `generates a JSON array` = {
+      generate(Queue(1, 2, 3)).must(be("[1,2,3]"))
+    }
+
+    @Test def `is parsable from a JSON array of ints` = {
+      parse[Queue[Int]]("[1,2,3]").must(be(Queue(1, 2, 3)))
+    }
+
+    @Test def `is parsable from an empty JSON array` = {
+      parse[Queue[Int]]("[]").must(be(Queue.empty))
+    }
+  }
+}

--- a/src/test/scala/com/codahale/jerkson/tests/JValueSpec.scala
+++ b/src/test/scala/com/codahale/jerkson/tests/JValueSpec.scala
@@ -2,53 +2,50 @@ package com.codahale.jerkson.tests
 
 import com.codahale.jerkson.Json._
 import com.codahale.jerkson.AST._
-import com.codahale.simplespec.Spec
-import org.junit.Test
+import org.scalatest.FlatSpec
+import org.scalatest.Matchers
 
-class JValueSpec extends Spec {
-  class `Selecting single nodes` {
-    @Test def `returns None with primitives` = {
-      (parse[JValue]("8") \ "blah").must(be(JNull))
-    }
-    
-    @Test def `returns None on nonexistent fields` = {
-      (parse[JValue]("{\"one\": \"1\"}") \ "two").must(be(JNull))
-    }
-    
-    @Test def `returns a JValue with an existing field` = {
-      (parse[JValue]("{\"one\": \"1\"}") \ "one").must(be(JString("1")))
-    }
+class JValueSpec extends FlatSpec with Matchers {
+  behavior of "Selecting single nodes"
+  it should "returns None with primitives" in {
+    (parse[JValue]("8") \ "blah") shouldBe JNull
   }
-  
-  class `Selecting array members` {
-    @Test def `returns None with primitives` = {
-      (parse[JValue]("\"derp\"").apply(0)).must(be(JNull))
-    }
-    
-    @Test def `returns None on out of bounds` = {
-      (parse[JValue]("[0, 1, 2, 3]").apply(4)).must(be(JNull))
-    }
-    
-    @Test def `returns a JValue` = {
-      (parse[JValue]("[0, 1, 2, 3]").apply(2)).must(be(JInt(2)))
-    }
-  }
-  
-  class `Deep selecting` {
-    @Test def `returns Nil with primitives` = {
-      (parse[JValue]("0.234") \\ "herp").must(be(empty))
-    }
 
-    @Test def `returns Nil on nothing found` = {
-      (parse[JValue]("{\"one\": {\"two\" : \"three\"}}") \\ "four").must(be(empty))
-    }
-    
-    @Test def `returns single leaf nodes` = {
-      (parse[JValue]("{\"one\": {\"two\" : \"three\"}}") \\ "two").must(be(Seq(JString("three"))))
-    }
-    
-    @Test def `should return multiple leaf nodes` = {
-      (parse[JValue]("{\"one\": {\"two\" : \"three\"}, \"four\": {\"two\" : \"five\"}}") \\ "two").must(be(Seq(JString("three"),JString("five"))))
-    }
+  it should "returns None on nonexistent fields" in {
+    (parse[JValue]("{\"one\": \"1\"}") \ "two") shouldBe JNull
+  }
+
+  it should "returns a JValue with an existing field" in {
+    (parse[JValue]("{\"one\": \"1\"}") \ "one") shouldBe JString("1")
+  }
+
+  behavior of "Selecting array members"
+  it should "returns None with primitives" in {
+    (parse[JValue]("\"derp\"").apply(0)) shouldBe JNull
+  }
+
+  it should "returns None on out of bounds" in {
+    (parse[JValue]("[0, 1, 2, 3]").apply(4)) shouldBe JNull
+  }
+
+  it should "returns a JValue" in {
+    (parse[JValue]("[0, 1, 2, 3]").apply(2)) shouldBe JInt(2)
+  }
+
+  behavior of "Deep selecting"
+  it should "returns Nil with primitives" in {
+    (parse[JValue]("0.234") \\ "herp") shouldBe empty
+  }
+
+  it should "returns Nil on nothing found" in {
+    (parse[JValue]("{\"one\": {\"two\" : \"three\"}}") \\ "four") shouldBe empty
+  }
+
+  it should "returns single leaf nodes" in {
+    (parse[JValue]("{\"one\": {\"two\" : \"three\"}}") \\ "two") shouldBe Seq(JString("three"))
+  }
+
+  it should "should return multiple leaf nodes" in {
+    (parse[JValue]("{\"one\": {\"two\" : \"three\"}, \"four\": {\"two\" : \"five\"}}") \\ "two") shouldBe Seq(JString("three"),JString("five"))
   }
 }

--- a/src/test/scala/com/codahale/jerkson/tests/JValueSpec.scala
+++ b/src/test/scala/com/codahale/jerkson/tests/JValueSpec.scala
@@ -1,0 +1,54 @@
+package com.codahale.jerkson.tests
+
+import com.codahale.jerkson.Json._
+import com.codahale.jerkson.AST._
+import com.codahale.simplespec.Spec
+import org.junit.Test
+
+class JValueSpec extends Spec {
+  class `Selecting single nodes` {
+    @Test def `returns None with primitives` = {
+      (parse[JValue]("8") \ "blah").must(be(JNull))
+    }
+    
+    @Test def `returns None on nonexistent fields` = {
+      (parse[JValue]("{\"one\": \"1\"}") \ "two").must(be(JNull))
+    }
+    
+    @Test def `returns a JValue with an existing field` = {
+      (parse[JValue]("{\"one\": \"1\"}") \ "one").must(be(JString("1")))
+    }
+  }
+  
+  class `Selecting array members` {
+    @Test def `returns None with primitives` = {
+      (parse[JValue]("\"derp\"").apply(0)).must(be(JNull))
+    }
+    
+    @Test def `returns None on out of bounds` = {
+      (parse[JValue]("[0, 1, 2, 3]").apply(4)).must(be(JNull))
+    }
+    
+    @Test def `returns a JValue` = {
+      (parse[JValue]("[0, 1, 2, 3]").apply(2)).must(be(JInt(2)))
+    }
+  }
+  
+  class `Deep selecting` {
+    @Test def `returns Nil with primitives` = {
+      (parse[JValue]("0.234") \\ "herp").must(be(empty))
+    }
+
+    @Test def `returns Nil on nothing found` = {
+      (parse[JValue]("{\"one\": {\"two\" : \"three\"}}") \\ "four").must(be(empty))
+    }
+    
+    @Test def `returns single leaf nodes` = {
+      (parse[JValue]("{\"one\": {\"two\" : \"three\"}}") \\ "two").must(be(Seq(JString("three"))))
+    }
+    
+    @Test def `should return multiple leaf nodes` = {
+      (parse[JValue]("{\"one\": {\"two\" : \"three\"}, \"four\": {\"two\" : \"five\"}}") \\ "two").must(be(Seq(JString("three"),JString("five"))))
+    }
+  }
+}

--- a/src/test/scala/com/codahale/jerkson/tests/MutableCollectionSupportSpec.scala
+++ b/src/test/scala/com/codahale/jerkson/tests/MutableCollectionSupportSpec.scala
@@ -1,189 +1,174 @@
 package com.codahale.jerkson.tests
 
-import com.codahale.simplespec.Spec
 import com.codahale.jerkson.Json._
-import scala.collection.mutable._
 import com.codahale.jerkson.ParsingException
-import org.junit.Test
+import org.scalatest.FlatSpec
+import org.scalatest.Matchers
+import scala.collection.mutable._
 
-class MutableCollectionSupportSpec extends Spec {
-  class `A mutable.ResizableArray[Int]` {
-    @Test def `generates a JSON array of ints` = {
-      generate(ResizableArray(1, 2, 3)).must(be("[1,2,3]"))
-    }
-
-    @Test def `is parsable from a JSON array of ints` = {
-      parse[ResizableArray[Int]]("[1,2,3]").must(be(ResizableArray(1, 2, 3)))
-    }
-
-    @Test def `is parsable from an empty JSON array` = {
-      parse[ResizableArray[Int]]("[]").must(be(ResizableArray.empty[Int]))
-    }
+class MutableCollectionSupportSpec extends FlatSpec with Matchers {
+  behavior of "A mutable.ResizableArray[Int]"
+  it should "generates a JSON array of ints" in {
+    generate(ResizableArray(1, 2, 3)) shouldBe "[1,2,3]"
   }
 
-  class `A mutable.ArraySeq[Int]` {
-    @Test def `generates a JSON array of ints` = {
-      generate(ArraySeq(1, 2, 3)).must(be("[1,2,3]"))
-    }
-
-
-    @Test def `is parsable from a JSON array of ints` = {
-      parse[ArraySeq[Int]]("[1,2,3]").must(be(ArraySeq(1, 2, 3)))
-    }
-
-    @Test def `is parsable from an empty JSON array` = {
-      parse[ArraySeq[Int]]("[]").must(be(ArraySeq.empty[Int]))
-    }
+  it should "is parsable from a JSON array of ints" in {
+    parse[ResizableArray[Int]]("[1,2,3]") shouldBe ResizableArray(1, 2, 3)
   }
 
-  class `A mutable.MutableList[Int]` {
-    private val xs = new MutableList[Int]
-    xs ++= List(1, 2, 3)
-
-    @Test def `generates a JSON array` = {
-      generate(xs).must(be("[1,2,3]"))
-    }
-
-    @Test def `is parsable from a JSON array of ints` = {
-      parse[MutableList[Int]]("[1,2,3]").must(be(xs))
-    }
-
-    @Test def `is parsable from an empty JSON array` = {
-      parse[MutableList[Int]]("[]").must(be(new MutableList[Int]()))
-    }
+  it should "is parsable from an empty JSON array" in {
+    parse[ResizableArray[Int]]("[]") shouldBe ResizableArray.empty[Int]
   }
 
-  class `A mutable.Queue[Int]` {
-    @Test def `generates a JSON array` = {
-      generate(Queue(1, 2, 3)).must(be("[1,2,3]"))
-    }
-
-    @Test def `is parsable from a JSON array of ints` = {
-      parse[Queue[Int]]("[1,2,3]").must(be(Queue(1, 2, 3)))
-    }
-
-    @Test def `is parsable from an empty JSON array` = {
-      parse[Queue[Int]]("[]").must(be(new Queue[Int]()))
-    }
+  behavior of "A mutable.ArraySeq[Int]"
+  it should "generates a JSON array of ints" in {
+    generate(ArraySeq(1, 2, 3)) shouldBe "[1,2,3]"
   }
 
-  class `A mutable.ListBuffer[Int]` {
-    @Test def `generates a JSON array` = {
-      generate(ListBuffer(1, 2, 3)).must(be("[1,2,3]"))
-    }
 
-    @Test def `is parsable from a JSON array of ints` = {
-      parse[ListBuffer[Int]]("[1,2,3]").must(be(ListBuffer(1, 2, 3)))
-    }
-
-    @Test def `is parsable from an empty JSON array` = {
-      parse[ListBuffer[Int]]("[]").must(be(ListBuffer.empty[Int]))
-    }
+  it should "is parsable from a JSON array of ints" in {
+    parse[ArraySeq[Int]]("[1,2,3]") shouldBe ArraySeq(1, 2, 3)
   }
 
-  class `A mutable.ArrayBuffer[Int]` {
-    @Test def `generates a JSON array` = {
-      generate(ArrayBuffer(1, 2, 3)).must(be("[1,2,3]"))
-    }
-
-    @Test def `is parsable from a JSON array of ints` = {
-      parse[ArrayBuffer[Int]]("[1,2,3]").must(be(ArrayBuffer(1, 2, 3)))
-    }
-
-    @Test def `is parsable from an empty JSON array` = {
-      parse[ArrayBuffer[Int]]("[]").must(be(ArrayBuffer.empty[Int]))
-    }
+  it should "is parsable from an empty JSON array" in {
+    parse[ArraySeq[Int]]("[]") shouldBe ArraySeq.empty[Int]
   }
 
-  class `A mutable.BitSet` {
-    @Test def `generates a JSON array` = {
-      generate(BitSet(1)).must(be("[1]"))
-    }
+  behavior of "A mutable.MutableList[Int]"
+  private val xs = new MutableList[Int]
+  xs ++= List(1, 2, 3)
 
-    @Test def `is parsable from a JSON array of ints` = {
-      parse[BitSet]("[1,2,3]").must(be(BitSet(1, 2, 3)))
-    }
-
-    @Test def `is parsable from an empty JSON array` = {
-      parse[BitSet]("[]").must(be(BitSet.empty))
-    }
+  it should "generates a JSON array" in {
+    generate(xs) shouldBe "[1,2,3]"
   }
 
-  class `A mutable.HashSet[Int]` {
-    @Test def `generates a JSON array` = {
-      generate(HashSet(1)).must(be("[1]"))
-    }
-
-    @Test def `is parsable from a JSON array of ints` = {
-      parse[HashSet[Int]]("[1,2,3]").must(be(HashSet(1, 2, 3)))
-    }
-
-    @Test def `is parsable from an empty JSON array` = {
-      parse[HashSet[Int]]("[]").must(be(HashSet.empty[Int]))
-    }
+  it should "is parsable from a JSON array of ints" in {
+    parse[MutableList[Int]]("[1,2,3]") shouldBe xs
   }
 
-  class `A mutable.LinkedHashSet[Int]` {
-    @Test def `generates a JSON array` = {
-      generate(LinkedHashSet(1)).must(be("[1]"))
-    }
-
-    @Test def `is parsable from a JSON array of ints` = {
-      parse[LinkedHashSet[Int]]("[1,2,3]").must(be(LinkedHashSet(1, 2, 3)))
-    }
-
-    @Test def `is parsable from an empty JSON array` = {
-      parse[LinkedHashSet[Int]]("[]").must(be(LinkedHashSet.empty[Int]))
-    }
+  it should "is parsable from an empty JSON array" in {
+    parse[MutableList[Int]]("[]") shouldBe new MutableList[Int]()
   }
 
-  class `A mutable.Map[String, Int]` {
-    @Test def `generates a JSON object` = {
-      generate(Map("one" -> 1)).must(be("""{"one":1}"""))
-    }
-
-    @Test def `is parsable from a JSON object with int field values` = {
-      parse[Map[String, Int]]("""{"one":1}""").must(be(Map("one" -> 1)))
-    }
-
-    @Test def `is parsable from an empty JSON object` = {
-      parse[Map[String, Int]]("{}").must(be(Map.empty[String, Int]))
-    }
+  behavior of "A mutable.Queue[Int]"
+  it should "generates a JSON array" in {
+    generate(Queue(1, 2, 3)) shouldBe "[1,2,3]"
   }
 
-  class `A mutable.Map[String, Any]` {
-    @Test def `is not parsable from an empty JSON object in a JSON array` = {
-      evaluating {
-        parse[Map[String, Any]]("[{}]")
-      }.must(throwA[ParsingException])
-    }
+  it should "is parsable from a JSON array of ints" in {
+    parse[Queue[Int]]("[1,2,3]") shouldBe Queue(1, 2, 3)
   }
 
-  class `A mutable.HashMap[String, Int]` {
-    @Test def `generates a JSON object` = {
-      generate(HashMap("one" -> 1)).must(be("""{"one":1}"""))
-    }
-
-    @Test def `is parsable from a JSON object with int field values` = {
-      parse[HashMap[String, Int]]("""{"one":1}""").must(be(HashMap("one" -> 1)))
-    }
-
-    @Test def `is parsable from an empty JSON object` = {
-      parse[HashMap[String, Int]]("{}").must(be(HashMap.empty[String, Int]))
-    }
+  it should "is parsable from an empty JSON array" in {
+    parse[Queue[Int]]("[]") shouldBe new Queue[Int]()
   }
 
-  class `A mutable.LinkedHashMap[String, Int]` {
-    @Test def `generates a JSON object` = {
-      generate(LinkedHashMap("one" -> 1)).must(be("""{"one":1}"""))
-    }
+  behavior of "A mutable.ListBuffer[Int]"
+  it should "generates a JSON array" in {
+    generate(ListBuffer(1, 2, 3)) shouldBe "[1,2,3]"
+  }
 
-    @Test def `is parsable from a JSON object with int field values` = {
-      parse[LinkedHashMap[String, Int]]("""{"one":1}""").must(be(LinkedHashMap("one" -> 1)))
-    }
+  it should "is parsable from a JSON array of ints" in {
+    parse[ListBuffer[Int]]("[1,2,3]") shouldBe ListBuffer(1, 2, 3)
+  }
 
-    @Test def `is parsable from an empty JSON object` = {
-      parse[LinkedHashMap[String, Int]]("{}").must(be(LinkedHashMap.empty[String, Int]))
-    }
+  it should "is parsable from an empty JSON array" in {
+    parse[ListBuffer[Int]]("[]") shouldBe ListBuffer.empty[Int]
+  }
+
+  behavior of "A mutable.ArrayBuffer[Int]"
+  it should "generates a JSON array" in {
+    generate(ArrayBuffer(1, 2, 3)) shouldBe "[1,2,3]"
+  }
+
+  it should "is parsable from a JSON array of ints" in {
+    parse[ArrayBuffer[Int]]("[1,2,3]") shouldBe ArrayBuffer(1, 2, 3)
+  }
+
+  it should "is parsable from an empty JSON array" in {
+    parse[ArrayBuffer[Int]]("[]") shouldBe ArrayBuffer.empty[Int]
+  }
+
+  behavior of "A mutable.BitSet"
+  it should "generates a JSON array" in {
+    generate(BitSet(1)) shouldBe "[1]"
+  }
+
+  it should "is parsable from a JSON array of ints" in {
+    parse[BitSet]("[1,2,3]") shouldBe BitSet(1, 2, 3)
+  }
+
+  it should "is parsable from an empty JSON array" in {
+    parse[BitSet]("[]") shouldBe BitSet.empty
+  }
+
+  behavior of "A mutable.HashSet[Int]"
+  it should "generates a JSON array" in {
+    generate(HashSet(1)) shouldBe "[1]"
+  }
+
+  it should "is parsable from a JSON array of ints" in {
+    parse[HashSet[Int]]("[1,2,3]") shouldBe HashSet(1, 2, 3)
+  }
+
+  it should "is parsable from an empty JSON array" in {
+    parse[HashSet[Int]]("[]") shouldBe HashSet.empty[Int]
+  }
+
+  behavior of "A mutable.LinkedHashSet[Int]"
+  it should "generates a JSON array" in {
+    generate(LinkedHashSet(1)) shouldBe "[1]"
+  }
+
+  it should "is parsable from a JSON array of ints" in {
+    parse[LinkedHashSet[Int]]("[1,2,3]") shouldBe LinkedHashSet(1, 2, 3)
+  }
+
+  it should "is parsable from an empty JSON array" in {
+    parse[LinkedHashSet[Int]]("[]") shouldBe LinkedHashSet.empty[Int]
+  }
+
+  behavior of "A mutable.Map[String, Int]"
+  it should "generates a JSON object" in {
+    generate(Map("one" -> 1)) shouldBe """{"one":1}"""
+  }
+
+  it should "is parsable from a JSON object with int field values" in {
+    parse[Map[String, Int]]("""{"one":1}""") shouldBe Map("one" -> 1)
+  }
+
+  it should "is parsable from an empty JSON object" in {
+    parse[Map[String, Int]]("{}") shouldBe Map.empty[String, Int]
+  }
+
+  behavior of "A mutable.Map[String, Any]"
+  it should "is not parsable from an empty JSON object in a JSON array" in {
+    a [ParsingException] should be thrownBy parse[Map[String, Any]]("[{}]")
+  }
+
+  behavior of "A mutable.HashMap[String, Int]"
+  it should "generates a JSON object" in {
+    generate(HashMap("one" -> 1)) shouldBe """{"one":1}"""
+  }
+
+  it should "is parsable from a JSON object with int field values" in {
+    parse[HashMap[String, Int]]("""{"one":1}""") shouldBe HashMap("one" -> 1)
+  }
+
+  it should "is parsable from an empty JSON object" in {
+    parse[HashMap[String, Int]]("{}") shouldBe HashMap.empty[String, Int]
+  }
+
+  behavior of "A mutable.LinkedHashMap[String, Int]"
+  it should "generates a JSON object" in {
+    generate(LinkedHashMap("one" -> 1)) shouldBe """{"one":1}"""
+  }
+
+  it should "is parsable from a JSON object with int field values" in {
+    parse[LinkedHashMap[String, Int]]("""{"one":1}""") shouldBe LinkedHashMap("one" -> 1)
+  }
+
+  it should "is parsable from an empty JSON object" in {
+    parse[LinkedHashMap[String, Int]]("{}") shouldBe LinkedHashMap.empty[String, Int]
   }
 }

--- a/src/test/scala/com/codahale/jerkson/tests/MutableCollectionSupportSpec.scala
+++ b/src/test/scala/com/codahale/jerkson/tests/MutableCollectionSupportSpec.scala
@@ -1,0 +1,189 @@
+package com.codahale.jerkson.tests
+
+import com.codahale.simplespec.Spec
+import com.codahale.jerkson.Json._
+import scala.collection.mutable._
+import com.codahale.jerkson.ParsingException
+import org.junit.Test
+
+class MutableCollectionSupportSpec extends Spec {
+  class `A mutable.ResizableArray[Int]` {
+    @Test def `generates a JSON array of ints` = {
+      generate(ResizableArray(1, 2, 3)).must(be("[1,2,3]"))
+    }
+
+    @Test def `is parsable from a JSON array of ints` = {
+      parse[ResizableArray[Int]]("[1,2,3]").must(be(ResizableArray(1, 2, 3)))
+    }
+
+    @Test def `is parsable from an empty JSON array` = {
+      parse[ResizableArray[Int]]("[]").must(be(ResizableArray.empty[Int]))
+    }
+  }
+
+  class `A mutable.ArraySeq[Int]` {
+    @Test def `generates a JSON array of ints` = {
+      generate(ArraySeq(1, 2, 3)).must(be("[1,2,3]"))
+    }
+
+
+    @Test def `is parsable from a JSON array of ints` = {
+      parse[ArraySeq[Int]]("[1,2,3]").must(be(ArraySeq(1, 2, 3)))
+    }
+
+    @Test def `is parsable from an empty JSON array` = {
+      parse[ArraySeq[Int]]("[]").must(be(ArraySeq.empty[Int]))
+    }
+  }
+
+  class `A mutable.MutableList[Int]` {
+    private val xs = new MutableList[Int]
+    xs ++= List(1, 2, 3)
+
+    @Test def `generates a JSON array` = {
+      generate(xs).must(be("[1,2,3]"))
+    }
+
+    @Test def `is parsable from a JSON array of ints` = {
+      parse[MutableList[Int]]("[1,2,3]").must(be(xs))
+    }
+
+    @Test def `is parsable from an empty JSON array` = {
+      parse[MutableList[Int]]("[]").must(be(new MutableList[Int]()))
+    }
+  }
+
+  class `A mutable.Queue[Int]` {
+    @Test def `generates a JSON array` = {
+      generate(Queue(1, 2, 3)).must(be("[1,2,3]"))
+    }
+
+    @Test def `is parsable from a JSON array of ints` = {
+      parse[Queue[Int]]("[1,2,3]").must(be(Queue(1, 2, 3)))
+    }
+
+    @Test def `is parsable from an empty JSON array` = {
+      parse[Queue[Int]]("[]").must(be(new Queue[Int]()))
+    }
+  }
+
+  class `A mutable.ListBuffer[Int]` {
+    @Test def `generates a JSON array` = {
+      generate(ListBuffer(1, 2, 3)).must(be("[1,2,3]"))
+    }
+
+    @Test def `is parsable from a JSON array of ints` = {
+      parse[ListBuffer[Int]]("[1,2,3]").must(be(ListBuffer(1, 2, 3)))
+    }
+
+    @Test def `is parsable from an empty JSON array` = {
+      parse[ListBuffer[Int]]("[]").must(be(ListBuffer.empty[Int]))
+    }
+  }
+
+  class `A mutable.ArrayBuffer[Int]` {
+    @Test def `generates a JSON array` = {
+      generate(ArrayBuffer(1, 2, 3)).must(be("[1,2,3]"))
+    }
+
+    @Test def `is parsable from a JSON array of ints` = {
+      parse[ArrayBuffer[Int]]("[1,2,3]").must(be(ArrayBuffer(1, 2, 3)))
+    }
+
+    @Test def `is parsable from an empty JSON array` = {
+      parse[ArrayBuffer[Int]]("[]").must(be(ArrayBuffer.empty[Int]))
+    }
+  }
+
+  class `A mutable.BitSet` {
+    @Test def `generates a JSON array` = {
+      generate(BitSet(1)).must(be("[1]"))
+    }
+
+    @Test def `is parsable from a JSON array of ints` = {
+      parse[BitSet]("[1,2,3]").must(be(BitSet(1, 2, 3)))
+    }
+
+    @Test def `is parsable from an empty JSON array` = {
+      parse[BitSet]("[]").must(be(BitSet.empty))
+    }
+  }
+
+  class `A mutable.HashSet[Int]` {
+    @Test def `generates a JSON array` = {
+      generate(HashSet(1)).must(be("[1]"))
+    }
+
+    @Test def `is parsable from a JSON array of ints` = {
+      parse[HashSet[Int]]("[1,2,3]").must(be(HashSet(1, 2, 3)))
+    }
+
+    @Test def `is parsable from an empty JSON array` = {
+      parse[HashSet[Int]]("[]").must(be(HashSet.empty[Int]))
+    }
+  }
+
+  class `A mutable.LinkedHashSet[Int]` {
+    @Test def `generates a JSON array` = {
+      generate(LinkedHashSet(1)).must(be("[1]"))
+    }
+
+    @Test def `is parsable from a JSON array of ints` = {
+      parse[LinkedHashSet[Int]]("[1,2,3]").must(be(LinkedHashSet(1, 2, 3)))
+    }
+
+    @Test def `is parsable from an empty JSON array` = {
+      parse[LinkedHashSet[Int]]("[]").must(be(LinkedHashSet.empty[Int]))
+    }
+  }
+
+  class `A mutable.Map[String, Int]` {
+    @Test def `generates a JSON object` = {
+      generate(Map("one" -> 1)).must(be("""{"one":1}"""))
+    }
+
+    @Test def `is parsable from a JSON object with int field values` = {
+      parse[Map[String, Int]]("""{"one":1}""").must(be(Map("one" -> 1)))
+    }
+
+    @Test def `is parsable from an empty JSON object` = {
+      parse[Map[String, Int]]("{}").must(be(Map.empty[String, Int]))
+    }
+  }
+
+  class `A mutable.Map[String, Any]` {
+    @Test def `is not parsable from an empty JSON object in a JSON array` = {
+      evaluating {
+        parse[Map[String, Any]]("[{}]")
+      }.must(throwA[ParsingException])
+    }
+  }
+
+  class `A mutable.HashMap[String, Int]` {
+    @Test def `generates a JSON object` = {
+      generate(HashMap("one" -> 1)).must(be("""{"one":1}"""))
+    }
+
+    @Test def `is parsable from a JSON object with int field values` = {
+      parse[HashMap[String, Int]]("""{"one":1}""").must(be(HashMap("one" -> 1)))
+    }
+
+    @Test def `is parsable from an empty JSON object` = {
+      parse[HashMap[String, Int]]("{}").must(be(HashMap.empty[String, Int]))
+    }
+  }
+
+  class `A mutable.LinkedHashMap[String, Int]` {
+    @Test def `generates a JSON object` = {
+      generate(LinkedHashMap("one" -> 1)).must(be("""{"one":1}"""))
+    }
+
+    @Test def `is parsable from a JSON object with int field values` = {
+      parse[LinkedHashMap[String, Int]]("""{"one":1}""").must(be(LinkedHashMap("one" -> 1)))
+    }
+
+    @Test def `is parsable from an empty JSON object` = {
+      parse[LinkedHashMap[String, Int]]("{}").must(be(LinkedHashMap.empty[String, Int]))
+    }
+  }
+}

--- a/src/test/scala/com/codahale/jerkson/tests/StreamingSpec.scala
+++ b/src/test/scala/com/codahale/jerkson/tests/StreamingSpec.scala
@@ -1,0 +1,23 @@
+package com.codahale.jerkson.tests
+
+import com.codahale.jerkson.Json._
+import java.io.ByteArrayInputStream
+import com.codahale.simplespec.Spec
+import org.junit.Test
+
+class StreamingSpec extends Spec {
+  class `Parsing a stream of objects` {
+    val json = """[
+      {"id":1, "name": "Coda"},
+      {"id":2, "name": "Niki"},
+      {"id":3, "name": "Biscuit"},
+      {"id":4, "name": "Louie"}
+    ]"""
+
+    @Test def `returns an iterator of stream elements` = {
+      stream[CaseClass](new ByteArrayInputStream(json.getBytes)).toList
+        .must(be(CaseClass(1, "Coda") :: CaseClass(2, "Niki") ::
+                  CaseClass(3, "Biscuit") :: CaseClass(4, "Louie") :: Nil))
+    }
+  }
+}

--- a/src/test/scala/com/codahale/jerkson/tests/StreamingSpec.scala
+++ b/src/test/scala/com/codahale/jerkson/tests/StreamingSpec.scala
@@ -2,22 +2,19 @@ package com.codahale.jerkson.tests
 
 import com.codahale.jerkson.Json._
 import java.io.ByteArrayInputStream
-import com.codahale.simplespec.Spec
-import org.junit.Test
+import org.scalatest.FlatSpec
+import org.scalatest.Matchers
 
-class StreamingSpec extends Spec {
-  class `Parsing a stream of objects` {
-    val json = """[
+class StreamingSpec extends FlatSpec with Matchers {
+  behavior of "Parsing a stream of objects"
+  val json = """[
       {"id":1, "name": "Coda"},
       {"id":2, "name": "Niki"},
       {"id":3, "name": "Biscuit"},
       {"id":4, "name": "Louie"}
     ]"""
 
-    @Test def `returns an iterator of stream elements` = {
-      stream[CaseClass](new ByteArrayInputStream(json.getBytes)).toList
-        .must(be(CaseClass(1, "Coda") :: CaseClass(2, "Niki") ::
-                  CaseClass(3, "Biscuit") :: CaseClass(4, "Louie") :: Nil))
-    }
+  it should "returns an iterator of stream elements" in {
+    stream[CaseClass](new ByteArrayInputStream(json.getBytes)).toList shouldBe CaseClass(1, "Coda") :: CaseClass(2, "Niki") :: CaseClass(3, "Biscuit") :: CaseClass(4, "Louie") :: Nil
   }
 }


### PR DESCRIPTION
This PR restores the old tests and converts them to scalatest.

Running tests:
```sh
$ sbt test
```

The tests are pretty fast. They take 2 seconds to run on my laptop.

Changes:
- Restore old tests
- Convert old tests to scalatest and get passing
- Update readme
- Enable parallel test execution.