### PR TITLE
Close parsers when done parsing.

### DIFF
--- a/src/main/scala/com/codahale/jerkson/FieldIterator.scala
+++ b/src/main/scala/com/codahale/jerkson/FieldIterator.scala
@@ -12,7 +12,7 @@ class FieldIterator(parser: JsonParser) extends Iterator[(String, JValue)] {
   parser.nextToken()
 
   def hasNext = parser.getCurrentToken != JsonToken.END_OBJECT && !parser.isClosed
-  def parse[A](parser: JsonParser)(implicit mf: Manifest[A]): A = Json.parse(parser, mf)
+  def parse[A](parser: JsonParser)(implicit mf: Manifest[A]): A = Json.parse(parser, mf, false)
 
   def next() = if (hasNext) {
     require(parser.getCurrentToken == JsonToken.FIELD_NAME)

--- a/src/main/scala/com/codahale/jerkson/Parser.scala
+++ b/src/main/scala/com/codahale/jerkson/Parser.scala
@@ -84,7 +84,7 @@ trait Parser extends Factory {
    */
   def canDeserialize[A](implicit mf: Manifest[A]) = mapper.canDeserialize(Types.build(mapper.getTypeFactory, mf))
 
-  private[jerkson] def parse[A](parser: JsonParser, mf: Manifest[A]): A = {
+  private[jerkson] def parse[A](parser: JsonParser, mf: Manifest[A], closeParser: Boolean = true): A = {
     try {
       if (mf.erasure == classOf[JValue] || mf.erasure == JNull.getClass) {
         val value: A = parser.getCodec.readValue(parser, Types.build(mapper.getTypeFactory, mf))
@@ -95,6 +95,9 @@ trait Parser extends Factory {
     } catch {
       case e: JsonProcessingException => throw ParsingException(e)
       case e: EOFException => throw new ParsingException("JSON document ended unexpectedly.", e)
+    } finally {
+      if(closeParser)
+        parser.close()
     }
   }
 }

--- a/src/main/scala/com/codahale/jerkson/StreamingIterator.scala
+++ b/src/main/scala/com/codahale/jerkson/StreamingIterator.scala
@@ -16,7 +16,7 @@ class StreamingIterator[A](parser: JsonParser, mf: Manifest[A])
   def hasNext = parser.getCurrentToken != JsonToken.END_ARRAY && !parser.isClosed
 
   def next() = if (hasNext) {
-    val value = parse[A](parser, mf)
+    val value = parse[A](parser, mf, false)
     parser.nextToken()
     value
   } else Iterator.empty.next()


### PR DESCRIPTION
This is generally not an issue, except when you're parsing json at extremely high throughput. I discovered this recently while working on some high throughput json parsing code where I noticed that my CPU was much lower than it should have been. Turns out Jerkson was getting into a bunch of synchronized waits because the parsers weren't being closed. 